### PR TITLE
Add more image layer options for backgrounds

### DIFF
--- a/src/object/game/world.lua
+++ b/src/object/game/world.lua
@@ -321,6 +321,7 @@ function World:loadImage(layer, depth)
         sprite.width = SCREEN_WIDTH
         sprite.height = SCREEN_HEIGHT
     end
+    sprite:setScale(layer.properties["scaleX"] or 1, layer.properties["scaleY"] or 1)
     self:addChild(sprite)
     self.image_layers[layer.name] = sprite
     if layer.name == "battleborder" then

--- a/src/object/game/world.lua
+++ b/src/object/game/world.lua
@@ -310,18 +310,18 @@ function World:loadImage(layer, depth)
     if layer.tintcolor then
         sprite:setColor(layer.tintcolor[1]/255, layer.tintcolor[2]/255, layer.tintcolor[3]/255)
     end
-    sprite:setSpeed(layer.properties["speedX"] or 0, layer.properties["speedY"] or 0)
-    if layer.properties["wrapX"] then
+    sprite:setSpeed(layer.properties["speedx"] or 0, layer.properties["speedy"] or 0)
+    if layer.properties["wrapx"] then
         sprite.wrap_texture_x = true
     end
-    if layer.properties["wrapY"] then
+    if layer.properties["wrapy"] then
         sprite.wrap_texture_y = true
     end
-    if layer.properties["fitScreen"] then
+    if layer.properties["fitscreen"] then
         sprite.width = SCREEN_WIDTH
         sprite.height = SCREEN_HEIGHT
     end
-    sprite:setScale(layer.properties["scaleX"] or 1, layer.properties["scaleY"] or 1)
+    sprite:setScale(layer.properties["scalex"] or 1, layer.properties["scaley"] or 1)
     self:addChild(sprite)
     self.image_layers[layer.name] = sprite
     if layer.name == "battleborder" then

--- a/src/object/game/world.lua
+++ b/src/object/game/world.lua
@@ -310,6 +310,13 @@ function World:loadImage(layer, depth)
     if layer.tintcolor then
         sprite:setColor(layer.tintcolor[1]/255, layer.tintcolor[2]/255, layer.tintcolor[3]/255)
     end
+    sprite:setSpeed(layer.properties["speedX"] or 0, layer.properties["speedY"] or 0)
+    if layer.properties["wrapX"] then
+        sprite.wrap_texture_x = true
+    end
+    if layer.properties["wrapY"] then
+        sprite.wrap_texture_y = true
+    end
     self:addChild(sprite)
     self.image_layers[layer.name] = sprite
     if layer.name == "battleborder" then

--- a/src/object/game/world.lua
+++ b/src/object/game/world.lua
@@ -317,6 +317,10 @@ function World:loadImage(layer, depth)
     if layer.properties["wrapY"] then
         sprite.wrap_texture_y = true
     end
+    if layer.properties["fitScreen"] then
+        sprite.width = SCREEN_WIDTH
+        sprite.height = SCREEN_HEIGHT
+    end
     self:addChild(sprite)
     self.image_layers[layer.name] = sprite
     if layer.name == "battleborder" then

--- a/src/object/sprite.lua
+++ b/src/object/sprite.lua
@@ -7,6 +7,9 @@ function Sprite:init(texture, x, y, width, height, path)
     self.path = path or ""
 
     self:setSprite(texture)
+    
+    self.wrap_texture_x = false
+    self.wrap_texture_y = false
 
     self.color_mask = {1, 1, 1}
     self.color_mask_alpha = 0
@@ -263,7 +266,15 @@ function Sprite:draw()
         shader:send("amount", self.color_mask_alpha)
     end
     if self.texture then
-        love.graphics.draw(self.texture)
+        if self.wrap_texture_x or self.wrap_texture_y then
+            self.texture:setWrap(self.wrap_texture_x and "repeat" or "clamp", self.wrap_texture_y and "repeat" or "clamp")
+            local quad = love.graphics.newQuad(-self.x, -self.y, self.width, self.height, self.width, self.height)
+            love.graphics.draw(self.texture, quad, -self.x, -self.y)
+            quad:release()
+            self.texture:setWrap("clamp", "clamp")
+        else
+            love.graphics.draw(self.texture)
+        end
     end
 
     super:draw(self)

--- a/src/object/sprite.lua
+++ b/src/object/sprite.lua
@@ -269,7 +269,7 @@ function Sprite:draw()
         if self.wrap_texture_x or self.wrap_texture_y then
             self.texture:setWrap(self.wrap_texture_x and "repeat" or "clamp", self.wrap_texture_y and "repeat" or "clamp")
             local quad = love.graphics.newQuad(-self.x, -self.y, self.width, self.height, self.texture:getWidth(), self.texture:getHeight())
-            love.graphics.draw(self.texture, quad, -self.x, -self.y)
+            love.graphics.draw(self.texture, quad, -self.x / self.scale_x, -self.y / self.scale_y)
             quad:release()
             self.texture:setWrap("clamp", "clamp")
         else

--- a/src/object/sprite.lua
+++ b/src/object/sprite.lua
@@ -268,7 +268,7 @@ function Sprite:draw()
     if self.texture then
         if self.wrap_texture_x or self.wrap_texture_y then
             self.texture:setWrap(self.wrap_texture_x and "repeat" or "clamp", self.wrap_texture_y and "repeat" or "clamp")
-            local quad = love.graphics.newQuad(-self.x, -self.y, self.width, self.height, self.width, self.height)
+            local quad = love.graphics.newQuad(-self.x, -self.y, self.width, self.height, self.texture:getWidth(), self.texture:getHeight())
             love.graphics.draw(self.texture, quad, -self.x, -self.y)
             quad:release()
             self.texture:setWrap("clamp", "clamp")


### PR DESCRIPTION
Adds some custom properties for use with image layers: `speedX` and `speedY` (numbers) set the speed of the image layer, `wrapX` and `wrapY` (bools) determine whether the texture should wrap horizontally and/or vertically, and `fitToScreen` (bool) extends the image to fit the screen (stretching it or repeating it based on `wrapX/Y`). `scaleX` and `scaleY` (numbers) set the scale of the image.

These allow for having scrolling images in the background, without potentially needing to manually repeat or scale an image to fit.