### PR TITLE
Fixed the offset of Noelle's portrait in the light world

### DIFF
--- a/data/actors/noelle_lw.lua
+++ b/data/actors/noelle_lw.lua
@@ -30,7 +30,7 @@ function actor:init()
     -- Path to this actor's portrait for dialogue (optional)
     self.portrait_path = "face/noelle"
     -- Offset position for this actor's portrait (optional)
-    self.portrait_offset = {-12, -10}
+    self.portrait_offset = {-19, -20}
 
     -- Whether this actor as a follower will blush when close to the player
     self.can_blush = false


### PR DESCRIPTION
Offsets to Noelle's face portrait are different in the Dark World and the Light World. Currently Kristal has the offset correct only in the Dark World, and this pr fixes it by changing the portrait offset for the noelle_lw actor.