### PR TITLE
Clear MOD_LOADING in Kristal.clearModState, fixing shader softlock

### DIFF
--- a/src/kristal.lua
+++ b/src/kristal.lua
@@ -1126,6 +1126,7 @@ function Kristal.clearModState()
     -- Clear disruptive active globals
     Object._clearCache()
     Draw._clearStacks()
+    MOD_LOADING = false
     -- End the current mod
     Kristal.callEvent(KRISTAL_EVENT.unload)
     Mod = nil


### PR DESCRIPTION
Previously, shader errors would cause this to never be cleared, resulting in MainMenu being unresponsive.