### PR TITLE
Red Buster size fix

### DIFF
--- a/src/engine/game/effects/rudebusterbeam.lua
+++ b/src/engine/game/effects/rudebusterbeam.lua
@@ -14,6 +14,8 @@ function RudeBusterBeam:init(red, x, y, tx, ty, after)
     self.target_y = ty
     self.red = red
 
+    if red then self:setScale(2.5) end
+
     self.rotation = Utils.angle(x, y, tx, ty) + math.rad(20)
     self.physics.speed = 24
     self.physics.friction = -1.5
@@ -106,6 +108,7 @@ function RudeBusterBeam:update()
         sprite:fadeOutSpeedAndRemove()
         sprite:setOrigin(0.5, 0.5)
         sprite:setScale(2, 1.8)
+        if self.red then sprite:setScale(2.5) end
         sprite.rotation = self.rotation
         sprite.alpha = self.alpha - 0.2
         sprite.layer = self.layer - 0.01


### PR DESCRIPTION
In DR's code, Red Buster's size is 2.5x, while Rude buster is just 2x. Kristal has both beams set to 2x.
 This is just fixing the inaccuracy that Kristal's had for a while.