### PR TITLE
Fixed Party Member level-up inaccuracies

### DIFF
--- a/src/engine/game/battle.lua
+++ b/src/engine/game/battle.lua
@@ -629,8 +629,8 @@ function Battle:onStateChange(old,new)
                 end
             end
             
-            for _,party in ipairs(Utils.removeDuplicates(party_to_lvl_up)) do
-                Game.level_up_count = Game.level_up_count + 1
+            Game.level_up_count = Game.level_up_count + 1
+            for _,party in ipairs(TableUtils.removeDuplicates(party_to_lvl_up)) do
                 party:onLevelUp(Game.level_up_count)
             end
 


### PR DESCRIPTION
Previously, the code increased the global level count once per party member, causing uneven level ups. I fixed that by putting the level up increment outside of the for loop.