### PR TITLE
Old Dual Heal formula config

### DIFF
--- a/configs/chapter1.json
+++ b/configs/chapter1.json
@@ -18,6 +18,7 @@
     "oldGameOver": true,             // The game over screen used in chapter 1
     "oldRudeBuster": true,           // Old Rude Buster damage calculation and effect
     "oldPacify": true,               // Removes the animation from the Pacify spell
+    "oldDualHealFormula": true,      // Old Dual Heal amount calculation
 
     "speechBubble": "round",         // Default enemy speech bubble style
 

--- a/configs/chapter2.json
+++ b/configs/chapter2.json
@@ -18,6 +18,7 @@
     "oldGameOver": false,            // The game over screen used in chapter 1
     "oldRudeBuster": true,           // Old Rude Buster damage calculation and effect
     "oldPacify": false,              // Removes the animation from the Pacify spell
+    "oldDualHealFormula": false,     // Old Dual Heal amount calculation
 
     "speechBubble": "cyber",         // Default enemy speech bubble style
 

--- a/configs/chapter3.json
+++ b/configs/chapter3.json
@@ -18,6 +18,7 @@
     "oldGameOver": false,            // The game over screen used in chapter 1
     "oldRudeBuster": false,          // Old Rude Buster damage calculation and effect
     "oldPacify": false,              // Removes the animation from the Pacify spell
+    "oldDualHealFormula": false,     // Old Dual Heal amount calculation
 
     "speechBubble": "cyber",         // Default enemy speech bubble style
 

--- a/configs/chapter4.json
+++ b/configs/chapter4.json
@@ -18,6 +18,7 @@
     "oldGameOver": false,            // The game over screen used in chapter 1
     "oldRudeBuster": false,          // Old Rude Buster damage calculation and effect
     "oldPacify": false,              // Removes the animation from the Pacify spell
+    "oldDualHealFormula": false,     // Old Dual Heal amount calculation
 
     "speechBubble": "cyber",         // Default enemy speech bubble style
 

--- a/data/spells/dual_heal.lua
+++ b/data/spells/dual_heal.lua
@@ -24,7 +24,7 @@ function spell:init()
 end
 
 function spell:onCast(user, target)
-    local base_heal = user.chara:getStat("magic") * 5.5
+    local base_heal = user.chara:getStat("magic") * (Game:getConfig("oldDualHealFormula") and 4 or 5.5)
     local heal_amount = Game.battle:applyHealBonuses(base_heal, user.chara)
 
     for _,battler in ipairs(target) do


### PR DESCRIPTION
In chapter 1, Dual Heal is calculated with "magic * 4", instead of "magic * 5.5" like it's done in chapters 2 and 3 (even if in chapter 3 it's unused)