### PR TITLE
SpinCake heal amount accuracy

### DIFF
--- a/data/items/items/spincake.lua
+++ b/data/items/items/spincake.lua
@@ -16,8 +16,12 @@ function item:init()
     -- Amount healed (HealItem variable)
     if Game.chapter == 1 then
         self.heal_amount = 80
-    else
+    elseif Game.chapter == 2 then
         self.heal_amount = 140
+    elseif Game.chapter == 3 then
+        self.heal_amount = 150
+    elseif Game.chapter >= 4 then
+        self.heal_amount = 160
     end
 
     -- Battle description


### PR DESCRIPTION
In one of the patches to chapters 3 and 4, not only Toby made SpinCake obtainable from Top Chef in Castle Town, but also changes it's heal amount in the new chapters.