### PR TITLE
EnemyBattler's :registerAct and similar functions now check for Game.battle.party

### DIFF
--- a/src/engine/game/battle/enemybattler.lua
+++ b/src/engine/game/battle/enemybattler.lua
@@ -213,8 +213,8 @@ function EnemyBattler:registerAct(name, description, party, tp, highlight, icons
     if type(party) == "string" then
         if party == "all" then
             party = {}
-            for _, chara in ipairs(Game.party) do
-                table.insert(party, chara.id)
+            for _, battler in ipairs(Game.battle.party) do
+                table.insert(party, battler.chara.id)
             end
         else
             party = { party }
@@ -248,7 +248,7 @@ function EnemyBattler:registerShortAct(name, description, party, tp, highlight, 
         if party == "all" then
             party = {}
             for _, battler in ipairs(Game.battle.party) do
-                table.insert(party, battler.id)
+                table.insert(party, battler.chara.id)
             end
         else
             party = { party }
@@ -281,8 +281,8 @@ function EnemyBattler:registerActFor(char, name, description, party, tp, highlig
     if type(party) == "string" then
         if party == "all" then
             party = {}
-            for _, chara in ipairs(Game.party) do
-                table.insert(party, chara.id)
+            for _, battler in ipairs(Game.battle.party) do
+                table.insert(party, battler.chara.id)
             end
         else
             party = { party }


### PR DESCRIPTION
Setting the `party` argument of `:registerAct` and adjacent functions to `"all"` while having more than 3 party members will cause the ACT to not show up due to them checking for `Game.party` instead of `Game.battle.party`. This commit should fix this issue.
Additionally, while `:registerShortAct` did check for Game.battle.party, it tried to access the `id` value of battlers instead (nil), which should've been `.chara.id`