### PR TITLE
FiberScarf attack bonus accuracy

### DIFF
--- a/data/items/weapons/fiberscarf.lua
+++ b/data/items/weapons/fiberscarf.lua
@@ -34,7 +34,7 @@ function item:init()
 
     -- Equip bonuses (for weapons and armor)
     self.bonuses = {
-        attack = 2,
+        attack = Game.chapter == 3 and 3 or 2,
         magic  = 2,
     }
     -- Bonus name and icon (displayed in equip menu)


### PR DESCRIPTION
Weirdly, specifically in chapter 3 and there only, the attack bonus of FiberScarf is set to 3 instead of usual 2.