### PR TITLE
Select Multiple Waves debug menu

### DIFF
--- a/src/engine/game/debugsystem.lua
+++ b/src/engine/game/debugsystem.lua
@@ -798,6 +798,9 @@ function DebugSystem:registerSubMenus()
         "[Start Waves]",
         "Start the selected waves.",
         function ()
+            if #self.selected_waves > #Game.battle:getActiveEnemies() then
+                return false
+            end
             -- WARNING: Prepare eye bleach before reading function
             if Game.battle:getState() == "ACTIONSELECT" then
                 -- Step 1: Creates a table of enemies that can (normally) use each wave
@@ -851,6 +854,10 @@ function DebugSystem:registerSubMenus()
                 end
                 Game.battle:setState("DEFENDINGBEGIN", self.selected_waves)
             end
+        end,
+        nil,
+        function ()
+            return #self.selected_waves > #Game.battle:getActiveEnemies() and COLORS.silver or COLORS.white
         end
     )
 
@@ -904,7 +911,7 @@ function DebugSystem:registerSubMenus()
             end,
             nil,
             function ()
-                return TableUtils.contains(self.selected_waves, id) and COLORS.aqua or #self.selected_waves == #Game.battle:getActiveEnemies() and COLORS.silver or COLORS.white
+                return TableUtils.contains(self.selected_waves, id) and COLORS.aqua or #self.selected_waves >= #Game.battle:getActiveEnemies() and COLORS.silver or COLORS.white
             end
         )
     end


### PR DESCRIPTION
(Completely repurposed PR because I'm Evil)

Adds a multiple wave selector to the debug menu (does what it says on the tin)
Also adds two cool new debug menu features to make that possible:
- Colored debug options (new last argument to `registerOption`, can be a function (dynamic color) or table (static color)
- Option to make debug options "fail" or otherwise play `ui_cant_select` instead of `ui_select` by returning `false` in their functions
Debug menus that have "selected" style elements will use the color feature as well (Spells, Party members & Music test)