### PR TITLE
Fixed an issue with pull request #483 (Event parallax)

### DIFF
--- a/src/engine/game/world/map.lua
+++ b/src/engine/game/world/map.lua
@@ -667,7 +667,7 @@ function Map:loadObjects(layer, depth, layer_type)
                 if obj then
                     obj.x = obj.x + (layer.offsetx or 0)
                     obj.y = obj.y + (layer.offsety or 0)
-                    obj:setParallax(layer.parallaxx, layer.parallaxy)
+                    obj:setParallax(obj.parallax_x * layer.parallaxx, obj.parallax_y * layer.parallaxy)
                     if not obj.object_id then
                         obj.object_id = v.id
                     end


### PR DESCRIPTION
Map:loadObjects now multiplies the event's original parallax instead of overriding it with the layer's, fixing the issue of parallax set in :init of the event being cancelled