### PR TITLE
Event parallax fix

### DIFF
--- a/src/engine/game/world/map.lua
+++ b/src/engine/game/world/map.lua
@@ -667,7 +667,7 @@ function Map:loadObjects(layer, depth, layer_type)
                 if obj then
                     obj.x = obj.x + (layer.offsetx or 0)
                     obj.y = obj.y + (layer.offsety or 0)
-                    obj:setParallax(obj.parallax_x * layer.parallaxx, obj.parallax_y * layer.parallaxy)
+                    obj:setParallax((obj.parallax_x or 1) * layer.parallaxx, (obj.parallax_y or 1) * layer.parallaxy)
                     if not obj.object_id then
                         obj.object_id = v.id
                     end


### PR DESCRIPTION
Apparently an object's parallax defaults to nil