### PR TITLE
Persist DamageNumber and RecruitMessage into the overworld

### DIFF
--- a/src/engine/game/effects/damagenumber.lua
+++ b/src/engine/game/effects/damagenumber.lua
@@ -194,7 +194,7 @@ end
 
 function DamageNumber:onRemoveFromStage(stage)
     super.onRemoveFromStage(self, stage)
-    if self.parent and self.parent:includes(Battle) then
+    if self.parent and self.parent:includes(Battle) and Game.world then
         local prev_x, prev_y = self.x, self.y
         local x, y = self:getScreenPos()
         self:setParent(Game.world)

--- a/src/engine/game/effects/recruitmessage.lua
+++ b/src/engine/game/effects/recruitmessage.lua
@@ -102,7 +102,7 @@ end
 
 function RecruitMessage:onRemoveFromStage(stage)
     super.onRemoveFromStage(self, stage)
-    if self.parent and self.parent:includes(Battle) then
+    if self.parent and self.parent:includes(Battle) and Game.world then
         local prev_x, prev_y = self.x, self.y
         local x, y = self:getScreenPos()
         self:setParent(Game.world)


### PR DESCRIPTION
Since Deltarune does not separate battles from the overworld through object parenting like Kristal does, they don't need to do anything special to achieve this effect.