### PR TITLE
Fix RecruitMessage crash due to attempting to apply changes to a non-…

### DIFF
--- a/src/engine/game/effects/recruitmessage.lua
+++ b/src/engine/game/effects/recruitmessage.lua
@@ -108,7 +108,6 @@ function RecruitMessage:onRemoveFromStage(stage)
         self:setParent(Game.world)
         self:setScreenPos(x, y)
         self.start_x = (self.start_x - prev_x) + self.x
-        self.start_y = (self.start_y - prev_y) + self.y
     end
 end
 


### PR DESCRIPTION
…existent variable

This was the result of a poor copy-paste job and not testing after doing so. There was a previous iteration of the logic that worked and I had tested so I didn't think of it. It's ALWAYS the "simple" changes.

Attached is a screenshot of the error that this fixes. (taken by @DIAMONDDELTAHEDRON) In this case, the Kristal error handler was quit resulting in onRemoveFromStage being retried.
<img width="887" height="391" alt="image" src="https://github.com/user-attachments/assets/e8d4ee33-51a3-4996-b595-10579d418a03" />
