### PR TITLE
Fixed get line intersect(But actually this time)

### DIFF
--- a/src/utils/utils.lua
+++ b/src/utils/utils.lua
@@ -1003,7 +1003,6 @@ function Utils.getLineIntersect(x1, y1, x2, y2, x3, y3, x4, y4, seg1, seg2)
             return false, "The lines don't intersect." 
         end
     end
-
     return x, y
 end
 


### PR DESCRIPTION
So I went back and tested it, the segment part of Utils.getLineIntersect seemed to mess up the results

<img width="326" height="514" alt="image" src="https://github.com/user-attachments/assets/d1c572b2-c1e4-49fb-b0ef-29617a507352" />

All of these lines are supposed to intersect, but one of them is segmented which messes stuff up.

This updated function should fix it.