### PR TITLE
Make darkconfigmenu's spacing more accurate.

### DIFF
--- a/src/engine/game/world/ui/dark/darkconfigmenu.lua
+++ b/src/engine/game/world/ui/dark/darkconfigmenu.lua
@@ -219,26 +219,26 @@ function DarkConfigMenu:draw()
         if self.state == "VOLUME" then
             Draw.setColor(PALETTE["world_text_selected"])
         end
-        love.graphics.print("Master Volume", 88, 38 + (0 * 32))
+        love.graphics.print("Master Volume", 88, 38 + (0 * 35))
         Draw.setColor(PALETTE["world_text"])
-        love.graphics.print("Controls", 88, 38 + (1 * 32))
-        love.graphics.print("Simplify VFX", 88, 38 + (2 * 32))
-        love.graphics.print("Fullscreen", 88, 38 + (3 * 32))
-        love.graphics.print("Auto-Run", 88, 38 + (4 * 32))
-        love.graphics.print("Return to Title", 88, 38 + (5 * 32))
-        love.graphics.print("Back", 88, 38 + (6 * 32))
+        love.graphics.print("Controls", 88, 38 + (1 * 35))
+        love.graphics.print("Simplify VFX", 88, 38 + (2 * 35))
+        love.graphics.print("Fullscreen", 88, 38 + (3 * 35))
+        love.graphics.print("Auto-Run", 88, 38 + (4 * 35))
+        love.graphics.print("Return to Title", 88, 38 + (5 * 35))
+        love.graphics.print("Back", 88, 38 + (6 * 35))
 
         if self.state == "VOLUME" then
             Draw.setColor(PALETTE["world_text_selected"])
         end
-        love.graphics.print(MathUtils.round(Kristal.getVolume() * 100) .. "%", 348, 38 + (0 * 32))
+        love.graphics.print(MathUtils.round(Kristal.getVolume() * 100) .. "%", 348, 38 + (0 * 35))
         Draw.setColor(PALETTE["world_text"])
-        love.graphics.print(Kristal.Config["simplifyVFX"] and "ON" or "OFF", 348, 38 + (2 * 32))
-        love.graphics.print(Kristal.Config["fullscreen"] and "ON" or "OFF", 348, 38 + (3 * 32))
-        love.graphics.print(Kristal.Config["autoRun"] and "ON" or "OFF", 348, 38 + (4 * 32))
+        love.graphics.print(Kristal.Config["simplifyVFX"] and "ON" or "OFF", 348, 38 + (2 * 35))
+        love.graphics.print(Kristal.Config["fullscreen"] and "ON" or "OFF", 348, 38 + (3 * 35))
+        love.graphics.print(Kristal.Config["autoRun"] and "ON" or "OFF", 348, 38 + (4 * 35))
 
         Draw.setColor(Game:getSoulColor())
-        Draw.draw(self.heart_sprite, 63, 48 + ((self.currently_selected - 1) * 32))
+        Draw.draw(self.heart_sprite, 63, 48 + ((self.currently_selected - 1) * 35))
     else
         -- NOTE: This is forced to true if using a PlayStation in DELTARUNE... Kristal doesn't have a PlayStation port though.
         local dualshock = Input.getControllerType() == "ps4"


### PR DESCRIPTION
Changes the spacing of the Config menu items from 32 to 35, making it accurate to DELTARUNE. (I hope, anyway...)

This applies to every chapter, according to JARU, so I don't check for the old Chapter 1 UI here. Thanks, DELTARUNE team, for letting me be lazy...