### PR TITLE
Better error upon incorrect tile layer format

### DIFF
--- a/src/engine/game/world/tilelayer.lua
+++ b/src/engine/game/world/tilelayer.lua
@@ -4,6 +4,7 @@ local TileLayer, super = Class(Object)
 
 function TileLayer:init(map, data)
     data = data or {}
+    assert(data.encoding == "lua", "Tile layer format \"" .. data.encoding .. "\" is not supported. Please set the format to CSV in the map properties.")
 
     self.map_width = data.width or map.width
     self.map_height = data.height or map.height


### PR DESCRIPTION
Before, the error would only happen upon trying to draw the tiles. Since it's a string instead of a table, error happens.

Perhaps in the future we could support compressed formats.