### PR TITLE
Don't make an empty tile layer in data-less maps

### DIFF
--- a/src/engine/game/world/map.lua
+++ b/src/engine/game/world/map.lua
@@ -84,8 +84,6 @@ function Map:load()
     self.world:addChild(self.timer)
     if self.data then
         self:loadMapData(self.data)
-    else
-        self:addTileLayer(0)
     end
     for _, event in ipairs(self.events) do
         if event.onLoad then


### PR DESCRIPTION
By data-less, I mean maps that only have a class file, not a data file. But anyway, this behavior caused a crash after #511. Sorry I didn't make this PR first!