### PR TITLE
Improve modRequire with caching and library support

### DIFF
--- a/src/kristal.lua
+++ b/src/kristal.lua
@@ -1375,6 +1375,8 @@ function Kristal.loadMod(id, save_id, save_name, after)
 
         -- Add the current library to the libs table (again, with the real final value)
         Mod.libs[lib_id] = lib
+        -- Cache the library to be accessible through modRequire/libRequire
+        Kristal.LoadedModScripts["libraries." .. lib_id .. ".lib"] = lib
     end
 
     Kristal.loadModAssets(mod.id, "all", "", after or function()


### PR DESCRIPTION
Sorry if I didn't do a good job explaining this, it's _5AM Again_

Basically the caching is like `package.loaded`, and `modRequire("libraries.mylib.thing")` is the same as `libRequire("mylib", "thing")` but actually with some degree language server support (of course LS will get confused if lib folder name differs from ID)

Motivation: I'm tired of creating and maintaining `globals.lua` files to trick the language server