### PR TITLE
Power Acts accuracy

### DIFF
--- a/src/engine/game/battle.lua
+++ b/src/engine/game/battle.lua
@@ -1673,12 +1673,12 @@ function Battle:powerAct(spell, battler, user, target)
         end
     end
 
-    local name = user_battler.chara:getName()
-    if name == "Ralsei" then
+    local name = user_battler.chara:getName():upper()
+    if name == "SUSIE" then
         -- deltarune inconsistency lol
-        name = "RALSEI"
+        name = "Susie"
     end
-    self:setActText("* Your soul shined its power on\n" .. name .. "!", true)
+    self:setActText("* Your SOUL shined its power on\n" .. name .. "!", true)
 
     self.timer:after(7 / 30, function()
         Assets.playSound("boost")


### PR DESCRIPTION
In Chapter 4, when we use the dual power act, the text says "* Your SOUL shined its power on RALSEI and SUSIE!", which makes it clear that it saying "Susie" (not in uppercase) in Chapters 1 and 2 was seemingly an oversight. This commit fixes that, now having power acts use always the uppercase writing for the name of the spell caster (and Susie being the exception now instead of Ralsei). Also, in all power acts "SOUL" was written in uppercase too, which for some reason wasn't the case in Kristal. It has been fixed as well.