### PR TITLE
More detailed error message for non-existent attacksound in battle

### DIFF
--- a/src/engine/game/battle.lua
+++ b/src/engine/game/battle.lua
@@ -1263,6 +1263,7 @@ function Battle:processAction(action)
         local attacksound = battler.chara:getWeapon() and battler.chara:getWeapon():getAttackSound(battler, enemy, action.points) or battler.chara:getAttackSound()
         local attackpitch  = battler.chara:getWeapon() and battler.chara:getWeapon():getAttackPitch(battler, enemy, action.points) or battler.chara:getAttackPitch()
         local src = Assets.stopAndPlaySound(attacksound or "laz_c")
+        assert(src, "Attempted to play non-existent attack sound \"" .. (attacksound or "laz_c") .. "\" for " .. battler.chara:getName())
         src:setPitch(attackpitch or 1)
 
         self.actions_done_timer = 1.2


### PR DESCRIPTION
This seems to be a fairly common error people encounter with a very unhelpful error message, this new error should give creators what they need to know to fix it independently