### PR TITLE
Call onWavesDone before setting up exit call in endWaves

### DIFF
--- a/src/engine/game/battle.lua
+++ b/src/engine/game/battle.lua
@@ -989,6 +989,8 @@ function Battle:endWaves()
 
     local ending_wave = self.state_reason == "WAVEENDED"
 
+    self.encounter:onWavesDone()
+
     if self:hasCutscene() then
         self.cutscene:after(function()
             exitWaves()
@@ -1004,8 +1006,6 @@ function Battle:endWaves()
             end
         end)
     end
-
-    self.encounter:onWavesDone()
 end
 
 --- Gets the location the soul should spawn at when waves start by default


### PR DESCRIPTION
This is so the user can start a cutscene in encounter:onWavesDone and it'd (presumably) work slightly more correctly