### PR TITLE
Fixed a bug with enemy.can_freeze being set to false

### DIFF
--- a/src/engine/game/battle/enemybattler.lua
+++ b/src/engine/game/battle/enemybattler.lua
@@ -952,7 +952,7 @@ function EnemyBattler:heal(amount, sparkle_color)
 end
 
 --- Freezes this enemy and defeats them with the reason `"FROZEN"` \
---- If this enemy can not be frozen, it acts as if it was defeated though violence
+--- If this enemy can not be frozen, it acts as if it was defeated though violence normally instead
 function EnemyBattler:freeze()
     if not self.can_freeze then
         self:onDefeat()


### PR DESCRIPTION
It would always make the enemy run away, even if enemy.exit_on_defeat is set to false. In addition, it still runs the rest of the code, causing the enemy to freeze while running away