### PR TITLE
Fixed many bugs with the main menu soul color being controlled by a mod

### DIFF
--- a/src/engine/menu/mainmenumodlist.lua
+++ b/src/engine/menu/mainmenumodlist.lua
@@ -175,8 +175,13 @@ function MainMenuModList:update()
         ---@cast button ModButton
         self.menu.heart_outline.visible = button:isFavorited()
         self.menu.heart_outline:setColor(button:getFavoritedColor())
+        self.menu.heart:setColor(Kristal.getSoulColor())
+        if MainMenu.mod_list:getSelectedMod().soulColor then
+            self.menu.heart:setColor(MainMenu.mod_list:getSelectedMod().soulColor)
+        end
     else
         self.menu.heart_outline.visible = false
+        self.menu.heart:setColor(Kristal.getSoulColor())
     end
 end
 

--- a/src/engine/menu/objects/modbutton.lua
+++ b/src/engine/menu/objects/modbutton.lua
@@ -56,11 +56,6 @@ function ModButton:onSelect()
     if self.preview_script and self.preview_script.onSelect then
         self.preview_script:onSelect(self)
     end
-
-    MainMenu.heart.color = { Kristal.getSoulColor() }
-    if MainMenu.mod_list:getSelectedMod().soulColor then
-        MainMenu.heart.color = MainMenu.mod_list:getSelectedMod().soulColor
-    end
 end
 
 function ModButton:onDeselect()


### PR DESCRIPTION
First, when you boot up Kristal (without a TARGET_MOD), it would cause the soul to change to the color of the first mod in the list, even if you haven't entered the mod list yet.

Secondly, it causes the soul color to stay the same if you hover on "Create a new project" when you hover on it right after the mod which changed the color.