### PR TITLE
Changed the default animation speed of recruits in the menu

### DIFF
--- a/src/engine/game/common/data/recruit.lua
+++ b/src/engine/game/common/data/recruit.lua
@@ -62,7 +62,7 @@ function Recruit:init()
 
     self.box_gradient_color = { 1, 1, 1, 1 }
 
-    self.box_sprite = { nil, 0, 0, 4 / 30 }
+    self.box_sprite = { nil, 0, 0, 0.25 }
 
     self.recruited = 0
 


### PR DESCRIPTION
Just to make it more consistent, the default animation speed of recruits in the recruit menu is now the same as the default animation speed of world bullets.