### PR TITLE
The default battle soul reset color back to red upon swapping back to it

### DIFF
--- a/src/engine/game/battle/soul.lua
+++ b/src/engine/game/battle/soul.lua
@@ -64,7 +64,7 @@ function Soul:init(x, y, color)
     if color then
         self:setColor(color)
     else
-        self:setColor(1, 0, 0)
+        self:setColor(Game.battle.encounter:getSoulColor())
     end
 
     self.layer = BATTLE_LAYERS["soul"]


### PR DESCRIPTION
if you do something like
Game.battle:swapSoul(Soul()) (you can do it without swapping from a different soul) The color will always be red again, instead of automatically being set to the soul character's color (or in this case, the encounter color)