### PR TITLE
Always validate shaders as GLES

### DIFF
--- a/src/engine/assets.lua
+++ b/src/engine/assets.lua
@@ -185,9 +185,9 @@ function Assets.parseData(data)
     ---@type {id:string,error:string}[]
     local errors = {}
     for key, shader_path in pairs(data.shader_paths) do
-        local ok, res = pcall(love.graphics.newShader, shader_path)
+        local ok, res = love.graphics.validateShader(true, shader_path)
         if ok then
-            self.data.shaders[key] = res
+            self.data.shaders[key] = love.graphics.newShader(shader_path)
         else
             errors[#errors + 1] = { id = key, error = res }
         end


### PR DESCRIPTION
Gone are the days of running a .love with whimsy in your heart, only to be overcome with despair as the shader divides a float by an integer.

**This will break projects that include shaders that aren't valid on mobile.** In fact, that's kinda The Point

To fix:
- Remove initial values from `uniform` declarations (`uniform float myfloat = 0.0;` -> `uniform float myfloat;`)
- Change literal numbers to the correct type (`myfloat / 2` -> `myfloat / 2.0`)
- If you really need to, explicitly cast numbers. (`myfloat / myinteger` -> `myfloat / float(myinteger)`