### PR TITLE
Added "cleanup" Kristal event

### DIFF
--- a/src/engine/vars.lua
+++ b/src/engine/vars.lua
@@ -219,7 +219,7 @@ KRISTAL_EVENT = {
     postDraw = "postDraw", -- finished drawing / at: Game:draw() / passes: NONE / returns: NONE
     save = "save", -- game is about to be saved / at: Game:save(x, y) / passes: table:save_data / returns: NONE
     unload = "unload", -- current game execution is stopped and data unloaded / at: Kristal.clearModState() / passes: NONE / returns: NONE
-    cleanup = "cleanup", -- current game execution is stopped and data unloaded or when the game encounters an error / at: Kristal.clearModState()\Kristal.errorHandler(msg, trace_level) / passes: is_error:boolean / returns: NONE
+    cleanup = "cleanup", -- current game execution is stopped and data unloaded or when the game encounters an error / at: Kristal.clearModState()\Kristal.errorHandler(msg, trace_level) / passes: NONE / returns: NONE
 
     --gameplay events--
     onBorderDraw = "onBorderDraw", -- game border draw time / at: [HOOK]love.draw(...)J\love.load(args) / passes: string:border, love.Image:border_texture / returns: NONE

--- a/src/kristal.lua
+++ b/src/kristal.lua
@@ -628,7 +628,7 @@ end
 function Kristal.errorHandler(msg, trace_level)
     if Mod then
         local status, err = pcall(function()
-            Kristal.callEvent(KRISTAL_EVENT.cleanup, true)
+            Kristal.callEvent(KRISTAL_EVENT.cleanup)
         end)
         if not status then
             -- msg = err
@@ -1167,7 +1167,7 @@ function Kristal.clearModState()
     Kristal.LoadedModScripts = {}
     -- End the current mod
     Kristal.callEvent(KRISTAL_EVENT.unload)
-    Kristal.callEvent(KRISTAL_EVENT.cleanup, false)
+    Kristal.callEvent(KRISTAL_EVENT.cleanup)
     Mod = nil
 
     Kristal.Mods.clear()


### PR DESCRIPTION
Runs when current game execution is stopped and data unloaded or when the game encounters an error.