### PR TITLE
Set the default color of the OverworldSoul to the soul chara color

### DIFF
--- a/src/engine/game/world/overworldsoul.lua
+++ b/src/engine/game/world/overworldsoul.lua
@@ -10,7 +10,7 @@ local OverworldSoul, super = Class(Object)
 function OverworldSoul:init(x, y)
     super.init(self, x, y)
 
-    self:setColor(1, 0, 0)
+    self:setColor(Game:getSoulColor())
 
     self.alpha = 0
 


### PR DESCRIPTION
Very minor fix.
If you spawn the soul manually, it would always be red instead of using the appropriate soul color.