### PR TITLE
Fix libRequire not working in main chunks

### DIFF
--- a/src/kristal.lua
+++ b/src/kristal.lua
@@ -1966,8 +1966,8 @@ function Kristal.executeLibScript(lib, path, ...)
         end
         return false
     else
-        local library = Mod.libs[lib]
-        local chunk = library and (library.info.script_chunks[path] or library.info.script_chunks[path .. "/init"])
+        local library = Mod.info.libs[lib]
+        local chunk = library and (library.script_chunks[path] or library.script_chunks[path .. "/init"])
         if not chunk then
             return false
         else


### PR DESCRIPTION
If you have a `local Something = modRequire("libraries.mylib.something")` at the top of `mylib/lib.lua`, it fails to find something.lua. This is Not good. So this fixes that