### PR TITLE
Mercy fix

### DIFF
--- a/src/engine/game/battle/enemybattler.lua
+++ b/src/engine/game/battle/enemybattler.lua
@@ -440,14 +440,7 @@ end
 
 --- Adds (or removes) mercy from this enemy
 ---@param amount number The amount of mercy being added (or removed, if set to negative)
----@param dontshowatfull boolean If set to `true`, doesn't show mercy messages if the bar is already full (defaults to `false`)
-function EnemyBattler:addMercy(amount, dontshowatfull)
-    if (dontshowatfull and amount >= 0 and self.mercy >= 100) or (amount < 0 and self.mercy <= 0) then
-        -- If we're already at full mercy and trying to add more with the dontshowatfull being set to true, do nothing.
-        -- Also do nothing if trying to remove from an empty mercy bar.
-        return
-    end
-
+function EnemyBattler:addMercy(amount)
     self.mercy = self.mercy + amount
     if self.mercy < 0 then
         self.mercy = 0


### PR DESCRIPTION
Currently, Kristal stops showing the mercy messages if the enemy's mercy reached 100%, which isn't exactly accurate to Deltarune. This change introduces more accurate approach by introducing a second argument to the addMercy() function, that allows to stop showing mercy messages if enemy's mercy is full, while by default they'll be always shown.