### PR TITLE
Fixed a bug with healing an overhealed party member

### DIFF
--- a/src/engine/game/battle/partybattler.lua
+++ b/src/engine/game/battle/partybattler.lua
@@ -297,18 +297,16 @@ end
 ---@param amount            number  The amount of health to restore
 ---@param sparkle_color?    table   The color of the heal sparkles (defaults to the standard green) or false to not show sparkles
 ---@param show_up?          boolean Whether the "UP" status message should show if the battler is revived by the heal
-function PartyBattler:heal(amount, sparkle_color, show_up)
-    Assets.stopAndPlaySound("power")
-
+---@param playsound?        boolean Whether to play a sound when healed
+function PartyBattler:heal(amount, sparkle_color, show_up, playsound)
     amount = math.floor(amount)
 
-    self.chara:setHealth(self.chara:getHealth() + amount)
+    local max_hp = self.chara:heal(amount, playsound)
 
     local was_down = self.is_down
     self:checkHealth(false)
 
-    if self.chara:getHealth() >= self.chara:getStat("health") then
-        self.chara:setHealth(self.chara:getStat("health"))
+    if max_hp then
         self:statusMessage("msg", "max", nil, nil, 8)
     else
         if show_up and was_down ~= self.is_down then

--- a/src/engine/game/common/data/partymember.lua
+++ b/src/engine/game/common/data/partymember.lua
@@ -392,8 +392,8 @@ function PartyMember:heal(amount, playsound)
     if playsound == nil or playsound then
         Assets.stopAndPlaySound("power")
     end
-    self:setHealth(math.min(self:getStat("health"), self:getHealth() + amount))
-    return self:getStat("health") == self:getHealth()
+    self:setHealth(math.min(math.max(self:getStat("health"), self:getHealth()), self:getHealth() + amount))
+    return self:getStat("health") <= self:getHealth()
 end
 
 --- Sets this party member's health value
@@ -418,7 +418,7 @@ function PartyMember:increaseStat(stat, amount, max)
         base_stats[stat] = max
     end
     if stat == "health" then
-        self:setHealth(math.min(self:getHealth() + amount, base_stats[stat]))
+        self:heal(amount, false)
     end
 end
 


### PR DESCRIPTION
Currently, if you attempt to heal a party member who has above their maximum health, it would just reduce their health to their maximum health instead.

This patch fixes this issue by simply not changing their health from their current one.