### PR TITLE
Added chain-skipping for text choice box

### DIFF
--- a/src/engine/game/common/textchoicebox.lua
+++ b/src/engine/game/common/textchoicebox.lua
@@ -156,6 +156,9 @@ function TextChoicebox:update()
                     end
                 end
             end
+        elseif self:canSkip() then
+            -- Chain skipping
+            self:update()
         end
     end
 end
@@ -186,6 +189,28 @@ function TextChoicebox:isTyping()
         end
     end
     return typing
+end
+
+function TextChoicebox:getCurrentTypingText()
+    if self.text and self.text:isTyping() then
+        return self.text
+    end
+
+    for _, text in ipairs(self.choices_text) do
+        if text:isTyping() then
+            return text
+        end
+    end
+
+    return nil
+end
+
+function TextChoicebox:canSkip()
+    local text = self:getCurrentTypingText()
+    if text and text.skippable and ((Input.down("cancel") and not text.state.noskip) or (Input.down("menu") and not text.state.noskip)) and not text.skip_speed then
+        return true
+    end
+    return false
 end
 
 function TextChoicebox:isDone()


### PR DESCRIPTION
In Deltarune & Undertale, when you skip text in the text choice box, it shows everything instantly.

because in this version, the dialogue only appear one after the other, if you press the skip button for just a moment, it won't show everything at once, only the current typing one. In addition, even if you hold the button, it would take a couple of frames to show everything.

I've tested it, it won't run self:update() more than required.