### PR TITLE
Fixed a very critical inaccuracy

### DIFF
--- a/data/party/kris.lua
+++ b/data/party/kris.lua
@@ -176,7 +176,7 @@ function character:onLevelUp(level)
 end
 
 function character:onPowerSelect(menu)
-    if MathUtils.random() < ((Game.chapter == 1) and 0.02 or 0.2) then
+    if MathUtils.random() < ((Game.chapter == 1) and 0.02 or 0.04) then
         self:setLocalWorldData("dog", true)
     else
         self:setLocalWorldData("dog", false)

--- a/data/party/kris.lua
+++ b/data/party/kris.lua
@@ -177,14 +177,14 @@ end
 
 function character:onPowerSelect(menu)
     if MathUtils.random() < ((Game.chapter == 1) and 0.02 or 0.04) then
-        Game.world:getPartyCharacter(self).kris_dog = true
+        self.kris_dog = true
     else
-        Game.world:getPartyCharacter(self).kris_dog = false
+        self.kris_dog = false
     end
 end
 
 function character:drawPowerStat(index, x, y, menu)
-    if index == (Game.chapter <= 3 and 1 or 2) and Game.world:getPartyCharacter(self).kris_dog then
+    if index == (Game.chapter <= 3 and 1 or 2) and self.kris_dog then
         local frames = Assets.getFrames("misc/dog_sleep")
         local frame = math.floor(Kristal.getTime()) % #frames + 1
         love.graphics.print("Dog:", x, y)

--- a/data/party/kris.lua
+++ b/data/party/kris.lua
@@ -176,15 +176,15 @@ function character:onLevelUp(level)
 end
 
 function character:onPowerSelect(menu)
-    if MathUtils.random() < ((Game.chapter == 1) and 0.02 or 0.04) then
-        self.kris_dog = true
+    if MathUtils.random() < ((Game.chapter == 1) and 0.02 or 0.2) then
+        self:setLocalWorldData("dog", true)
     else
-        self.kris_dog = false
+        self:setLocalWorldData("dog", false)
     end
 end
 
 function character:drawPowerStat(index, x, y, menu)
-    if index == (Game.chapter <= 3 and 1 or 2) and self.kris_dog then
+    if index == (Game.chapter <= 3 and 1 or 2) and self:getLocalWorldData("dog", false) then
         local frames = Assets.getFrames("misc/dog_sleep")
         local frame = math.floor(Kristal.getTime()) % #frames + 1
         love.graphics.print("Dog:", x, y)

--- a/data/party/kris.lua
+++ b/data/party/kris.lua
@@ -177,14 +177,14 @@ end
 
 function character:onPowerSelect(menu)
     if MathUtils.random() < ((Game.chapter == 1) and 0.02 or 0.04) then
-        menu.kris_dog = true
+        Game.world:getPartyCharacter(self).kris_dog = true
     else
-        menu.kris_dog = false
+        Game.world:getPartyCharacter(self).kris_dog = false
     end
 end
 
 function character:drawPowerStat(index, x, y, menu)
-    if index == 1 and menu.kris_dog then
+    if index == (Game.chapter <= 3 and 1 or 2) and Game.world:getPartyCharacter(self).kris_dog then
         local frames = Assets.getFrames("misc/dog_sleep")
         local frame = math.floor(Kristal.getTime()) % #frames + 1
         love.graphics.print("Dog:", x, y)

--- a/data/party/ralsei.lua
+++ b/data/party/ralsei.lua
@@ -193,9 +193,9 @@ end
 
 function character:onPowerSelect(menu)
     if MathUtils.random() < 0.02 then
-        self.ralsei_dog = true
+        self:setLocalWorldData("dog", true)
     else
-        self.ralsei_dog = false
+        self:setLocalWorldData("dog", false)
     end
 end
 
@@ -203,7 +203,7 @@ function character:drawPowerStat(index, x, y, menu)
     if index == 1 then
         if Game.chapter == 1 then
             -- Chapter 1 Ralsei "Kindness" stat (doggable)
-            if not self.ralsei_dog then
+            if not self:getLocalWorldData("dog", false) then
                 local icon = Assets.getTexture("ui/menu/icon/smile")
                 Draw.draw(icon, x-26, y+6, 0, 2, 2)
                 love.graphics.print("Kindness", x, y)

--- a/data/party/ralsei.lua
+++ b/data/party/ralsei.lua
@@ -193,9 +193,9 @@ end
 
 function character:onPowerSelect(menu)
     if MathUtils.random() < 0.02 then
-        Game.world:getPartyCharacter(self).ralsei_dog = true
+        self.ralsei_dog = true
     else
-        Game.world:getPartyCharacter(self).ralsei_dog = false
+        self.ralsei_dog = false
     end
 end
 
@@ -203,7 +203,7 @@ function character:drawPowerStat(index, x, y, menu)
     if index == 1 then
         if Game.chapter == 1 then
             -- Chapter 1 Ralsei "Kindness" stat (doggable)
-            if not Game.world:getPartyCharacter(self).ralsei_dog then
+            if not self.ralsei_dog then
                 local icon = Assets.getTexture("ui/menu/icon/smile")
                 Draw.draw(icon, x-26, y+6, 0, 2, 2)
                 love.graphics.print("Kindness", x, y)

--- a/data/party/ralsei.lua
+++ b/data/party/ralsei.lua
@@ -193,9 +193,9 @@ end
 
 function character:onPowerSelect(menu)
     if MathUtils.random() < 0.02 then
-        menu.ralsei_dog = true
+        Game.world:getPartyCharacter(self).ralsei_dog = true
     else
-        menu.ralsei_dog = false
+        Game.world:getPartyCharacter(self).ralsei_dog = false
     end
 end
 
@@ -203,7 +203,7 @@ function character:drawPowerStat(index, x, y, menu)
     if index == 1 then
         if Game.chapter == 1 then
             -- Chapter 1 Ralsei "Kindness" stat (doggable)
-            if not menu.ralsei_dog then
+            if not Game.world:getPartyCharacter(self).ralsei_dog then
                 local icon = Assets.getTexture("ui/menu/icon/smile")
                 Draw.draw(icon, x-26, y+6, 0, 2, 2)
                 love.graphics.print("Kindness", x, y)

--- a/src/engine/game/common/data/partymember.lua
+++ b/src/engine/game/common/data/partymember.lua
@@ -689,6 +689,36 @@ function PartyMember:getBaseStat(name, default, light)
     return (self:getBaseStats(light)[name] or (default or 0))
 end
 
+--- Gets the value of the temporary world data for this party member named `World.party_data`, returning `default` if the flag does not exist
+--- The value resets upon loading a new map
+function PartyMember:getLocalWorldData(name, default)
+    local result = Game.world.party_data[self.id][name]
+    if result == nil then
+        return default
+    else
+        return result
+    end
+end
+
+--- Sets the value of the temporary world data for this party member named `World.party_data` to `value`
+--- The value resets upon loading a new map
+---@param name  string
+---@param value any
+function PartyMember:setLocalWorldData(name, value)
+    Game.world.party_data[self.id][name] = value
+end
+
+--- Adds `amount` to a numeric temporary world data for this party member named `World.party_data` (or defines it if it does not exist)
+--- The value resets upon loading a new map
+---@param name      string  The name of the flag to add to
+---@param amount?   number  (Defaults to `1`)
+---@return number new_value
+function PartyMember:addLocalWorldData(name, amount)
+    local data = Game.world.party_data[self.id]
+    data[name] = (data[name] or 0) + (amount or 1)
+    return data[name]
+end
+
 --- Gets the value of the flag for this party member named `flag`, returning `default` if the flag does not exist
 function PartyMember:getFlag(name, default)
     local result = self.flags[name]

--- a/src/engine/game/world.lua
+++ b/src/engine/game/world.lua
@@ -958,6 +958,12 @@ end
 ---@param callback? fun()       A callback to run once the map has finished loading (Post Map:onEnter())
 ---@param ... unknown           Additional arguments that will be passed forward into Map:onEnter()
 function World:loadMap(...)
+    -- reset world party data when loading a new map
+    self.party_data = {}
+    for id, _ in pairs(Game.party_data) do
+        self.party_data[id] = {}
+    end
+    
     local args = { ... }
     -- x, y, facing, callback
     local map = table.remove(args, 1)


### PR DESCRIPTION
Kris's dog in the dark stat menu will not disappear upon re-opening the stat menu, only if you hover towards someone else.

In addition, in Chapter 4, it appears in the second slot.

Furthermore, if you load the next map, it will disappear; because of this, I've used "Game.world.party_data" instead of just "self".

Ralsei's dog is probably affected by this as well, but it cannot be seen as he's the third party member, so it was applied to him as well.