### PR TITLE
Use getPath when setting the texture at the end of crossfading

### DIFF
--- a/src/engine/objects/sprite.lua
+++ b/src/engine/objects/sprite.lua
@@ -453,7 +453,7 @@ function Sprite:crossFadeToSpeed(texture, speed, fade_out, after)
     self.crossfade_speed = speed or 0.04
     self.crossfade_out = fade_out
     self.crossfade_after = function(self)
-        self:setTexture(texture)
+        self:setTexture(self:getPath(texture))
         self:resetCrossFade()
         if after then after(self) end
     end


### PR DESCRIPTION
Fixes an issue where the actor sprite would immediately vanish upon finishing the crossfade