### PR TITLE
Fix music test preview not fading out after mod reload

### DIFF
--- a/src/engine/game/debugsystem.lua
+++ b/src/engine/game/debugsystem.lua
@@ -951,7 +951,10 @@ function DebugSystem:registerSubMenus()
         "music_test",
         function()
             self:fadeMusicOut(0)
-            if self.music then self.music:stop() end
+            if self.music then
+                self.music:remove()
+                self.music = nil
+            end
             self.music = Music()
         end
     )
@@ -962,7 +965,8 @@ function DebugSystem:registerSubMenus()
             self.music:fade(
                 0, 0.5,
                 function()
-                    self.music:stop()
+                    self.music:remove()
+                    self.music = nil
                 end
             )
         end

--- a/src/engine/game/debugsystem.lua
+++ b/src/engine/game/debugsystem.lua
@@ -951,6 +951,8 @@ function DebugSystem:registerSubMenus()
         "music_test",
         function()
             self:fadeMusicOut(0)
+            if self.music then self.music:stop() end
+            self.music = Music()
         end
     )
     self:registerMenuLeave(


### PR DESCRIPTION
Re-instantiates self.music every time the music test debug menu is entered, otherwise it gets orphaned after mod reload and the fader in self:registerMenuLeave() doesn't work.

Before fix:
https://github.com/user-attachments/assets/486170e3-9504-4935-9818-4efbeecb428e

After fix:
https://github.com/user-attachments/assets/f7ed7e04-4cba-439c-a7d4-6798f4659d04