### PR TITLE
Added Item:onWorldDamage and Item:onBattleDamage

### DIFF
--- a/src/engine/game/battle/partybattler.lua
+++ b/src/engine/game/battle/partybattler.lua
@@ -149,7 +149,7 @@ function PartyBattler:hurt(amount, exact, color, options)
             local element = 0
             amount = math.ceil((amount * self:getElementReduction(element)))
         end
-        for i,item in ipairs(self.chara:getEquipment()) do
+        for _, item in ipairs(self.chara:getEquipment()) do
             amount = item:onBattleDamage(amount, swoon, false) or amount
         end
 
@@ -166,7 +166,7 @@ function PartyBattler:hurt(amount, exact, color, options)
                 amount = math.ceil((3 * amount) / 4) -- Slightly different than the above
             end
         end
-        for i,item in ipairs(self.chara:getEquipment()) do
+        for _, item in ipairs(self.chara:getEquipment()) do
             amount = item:onBattleDamage(amount, swoon, true) or amount
         end
 

--- a/src/engine/game/battle/partybattler.lua
+++ b/src/engine/game/battle/partybattler.lua
@@ -149,6 +149,9 @@ function PartyBattler:hurt(amount, exact, color, options)
             local element = 0
             amount = math.ceil((amount * self:getElementReduction(element)))
         end
+        for i,item in ipairs(self.chara:getEquipment()) do
+            amount = item:onBattleDamage(amount, swoon, false) or amount
+        end
 
         self:removeHealth(amount, swoon)
     else
@@ -162,6 +165,9 @@ function PartyBattler:hurt(amount, exact, color, options)
             if self.defending then
                 amount = math.ceil((3 * amount) / 4) -- Slightly different than the above
             end
+        end
+        for i,item in ipairs(self.chara:getEquipment()) do
+            amount = item:onBattleDamage(amount, swoon, true) or amount
         end
 
         self:removeHealthBroken(amount, swoon) -- Use a separate function for cleanliness

--- a/src/engine/game/common/data/item.lua
+++ b/src/engine/game/common/data/item.lua
@@ -171,14 +171,14 @@ function Item:onBattleUpdate(battler) end
 
 --- *(Override)* Called before a Character takes damage from a world bullet
 ---@param amount The damage of the incoming hit
----@return number|nil New damage amount
+---@return number? New damage amount
 function Item:onWorldDamage(amount) end
 
 --- *(Override)* Called before a PartyBattler takes damage
 ---@param amount The damage of the incoming hit
 ---@param swoon  Whether the damage will swoon the battler instead of downing them
 ---@param all    Whether the damage being taken comes from a strike targeting the whole party
----@return number|nil New damage amount
+---@return number? New damage amount
 function Item:onBattleDamage(amount, swoon, all) end
 
 --- *(Override)* Called after an attack from a party member with this item equipped hits an enemy

--- a/src/engine/game/common/data/item.lua
+++ b/src/engine/game/common/data/item.lua
@@ -169,6 +169,18 @@ function Item:onWorldUpdate(chara) end
 ---@param battler PartyBattler The equipping character
 function Item:onBattleUpdate(battler) end
 
+--- *(Override)* Called before a Character takes damage from a world bullet
+---@param amount The damage of the incoming hit
+---@return number|nil New damage amount
+function Item:onWorldDamage(amount) end
+
+--- *(Override)* Called before a PartyBattler takes damage
+---@param amount The damage of the incoming hit
+---@param swoon  Whether the damage will swoon the battler instead of downing them
+---@param all    Whether the damage being taken comes from a strike targeting the whole party
+---@return number|nil New damage amount
+function Item:onBattleDamage(amount, swoon, all) end
+
 --- *(Override)* Called after an attack from a party member with this item equipped hits an enemy
 ---@param battler PartyBattler The attacking character
 ---@param enemy EnemyBattler The enemy hit by the attack

--- a/src/engine/game/world.lua
+++ b/src/engine/game/world.lua
@@ -189,7 +189,7 @@ function World:hurtParty(battler, amount)
     for _, party in ipairs(Game.party) do
         local current_amount = amount
 
-        for i,item in ipairs(party:getEquipment()) do
+        for _, item in ipairs(party:getEquipment()) do
             current_amount = item:onWorldDamage(current_amount) or current_amount
         end
 

--- a/src/engine/game/world.lua
+++ b/src/engine/game/world.lua
@@ -187,9 +187,15 @@ function World:hurtParty(battler, amount)
     local any_killed = false
     local any_alive = false
     for _, party in ipairs(Game.party) do
+        local current_amount = amount
+
+        for i,item in ipairs(party:getEquipment()) do
+            current_amount = item:onWorldDamage(current_amount) or current_amount
+        end
+
         if not battler or battler == party.id or battler == party then
             local current_health = party:getHealth()
-            party:setHealth(party:getHealth() - amount)
+            party:setHealth(party:getHealth() - current_amount)
             if party:getHealth() <= 0 then
                 party:setHealth(1)
                 any_killed = true
@@ -204,7 +210,7 @@ function World:hurtParty(battler, amount)
                     char:statusMessage("damage", dealt_amount)
                 end
             end
-        elseif party:getHealth() > amount then
+        elseif party:getHealth() > current_amount then
             any_alive = true
         end
     end


### PR DESCRIPTION
Turns out equipment can react to the damage you will deal to an enemy but not to the damage you're about to take
This PR adds callbacks for this situation, with the possibility to change how much damage you're about to get hit with