### PR TITLE
Rewrite TileLayer to use sprite batches

### DIFF
--- a/src/engine/game/world/map.lua
+++ b/src/engine/game/world/map.lua
@@ -834,6 +834,8 @@ function Map:loadTilesetFromTilesetPath(filename)
     return true, tileset
 end
 
+---@return Tileset?
+---@return integer
 function Map:getTileset(id)
     if type(id) == "number" then
         id = TiledUtils.parseTileGid(id)

--- a/src/engine/game/world/tilelayer.lua
+++ b/src/engine/game/world/tilelayer.lua
@@ -91,7 +91,7 @@ function TileLayer:regenerateTiles()
 
     self.unbatched_tiles = {}
     self.sprite_batches = {}
-    ---@type table<string, love.SpriteBatch>
+    ---@type table<Tileset, love.SpriteBatch>
     local tileset_sprite_batches = {}
     for i, xid in ipairs(self.tile_data) do
         local tx = ((i - 1) % self.map_width) * grid_w
@@ -111,10 +111,10 @@ function TileLayer:regenerateTiles()
                     }
                 )
             else
-                local batch = tileset_sprite_batches[tileset.id]
+                local batch = tileset_sprite_batches[tileset]
                 if batch == nil then
                     batch = love.graphics.newSpriteBatch(tileset.texture)
-                    tileset_sprite_batches[tileset.id] = batch
+                    tileset_sprite_batches[tileset] = batch
                     table.insert(self.sprite_batches, batch)
                 end
                 tileset:addTileToBatch(batch, id, tx, ty, grid_w, grid_h, flip_x, flip_y, flip_diag)

--- a/src/engine/game/world/tilelayer.lua
+++ b/src/engine/game/world/tilelayer.lua
@@ -1,8 +1,11 @@
 ---@class TileLayer : Object
 ---@field private drawn boolean
 ---@field private sprite_batches love.SpriteBatch[]
+---@field private unbatched_tiles TileLayer.UnbatchedTileData[]
 ---@overload fun(...) : TileLayer
 local TileLayer, super = Class(Object)
+
+---@alias TileLayer.UnbatchedTileData table
 
 ---@param map Map
 function TileLayer:init(map, data)
@@ -39,7 +42,7 @@ function TileLayer:init(map, data)
         end
     end
 
-    self.animated_tiles = {}
+    self.unbatched_tiles = {}
 
     self.sprite_batches = {}
     self.drawn = false
@@ -86,7 +89,7 @@ function TileLayer:regenerateTiles()
     local grid_w, grid_h = self.map.tile_width, self.map.tile_height
     Draw.setColor(r, g, b, self.tile_opacity)
 
-    self.animated_tiles = {}
+    self.unbatched_tiles = {}
     self.sprite_batches = {}
     ---@type table<string, love.SpriteBatch>
     local tileset_sprite_batches = {}
@@ -99,7 +102,7 @@ function TileLayer:regenerateTiles()
         if tileset then
             if tileset.texture == nil or tileset:getAnimation(id) ~= nil then
                 table.insert(
-                    self.animated_tiles,
+                    self.unbatched_tiles,
                     {
                         tileset = tileset, id = id,
                         x = tx, y = ty,
@@ -138,7 +141,7 @@ function TileLayer:draw()
     love.graphics.setBlendMode("alpha")
 
     Draw.setColor(r, g, b, a * self.tile_opacity)
-    for _, tile in ipairs(self.animated_tiles) do
+    for _, tile in ipairs(self.unbatched_tiles) do
         tile.tileset:drawGridTile(tile.id, tile.x, tile.y, grid_w, grid_h, tile.flip_x, tile.flip_y, tile.flip_diag)
     end
 

--- a/src/engine/game/world/tilelayer.lua
+++ b/src/engine/game/world/tilelayer.lua
@@ -1,5 +1,6 @@
 ---@class TileLayer : Object
 ---@field private drawn boolean
+---@field private sprite_batches love.SpriteBatch[]
 ---@overload fun(...) : TileLayer
 local TileLayer, super = Class(Object)
 
@@ -40,7 +41,7 @@ function TileLayer:init(map, data)
 
     self.animated_tiles = {}
 
-    self.canvas = love.graphics.newCanvas(self.map_width * map.tile_width, self.map_height * map.tile_height)
+    self.sprite_batches = {}
     self.drawn = false
 
     self.debug_select = false
@@ -85,11 +86,10 @@ function TileLayer:regenerateTiles()
     local grid_w, grid_h = self.map.tile_width, self.map.tile_height
     Draw.setColor(r, g, b, self.tile_opacity)
 
-    Draw.pushCanvas(self.canvas)
-    love.graphics.clear()
-    love.graphics.push()
-    love.graphics.origin()
     self.animated_tiles = {}
+    self.sprite_batches = {}
+    ---@type table<string, love.SpriteBatch>
+    local tileset_sprite_batches = {}
     for i, xid in ipairs(self.tile_data) do
         local tx = ((i - 1) % self.map_width) * grid_w
         local ty = math.floor((i - 1) / self.map_width) * grid_h
@@ -97,9 +97,7 @@ function TileLayer:regenerateTiles()
         local gid, flip_x, flip_y, flip_diag = TiledUtils.parseTileGid(xid)
         local tileset, id = self.map:getTileset(gid)
         if tileset then
-            if not tileset:getAnimation(id) then
-                tileset:drawGridTile(id, tx, ty, grid_w, grid_h, flip_x, flip_y, flip_diag)
-            else
+            if tileset.texture == nil or tileset:getAnimation(id) ~= nil then
                 table.insert(
                     self.animated_tiles,
                     {
@@ -109,11 +107,17 @@ function TileLayer:regenerateTiles()
                         flip_diag = flip_diag
                     }
                 )
+            else
+                local batch = tileset_sprite_batches[tileset.id]
+                if batch == nil then
+                    batch = love.graphics.newSpriteBatch(tileset.texture)
+                    tileset_sprite_batches[tileset.id] = batch
+                    table.insert(self.sprite_batches, batch)
+                end
+                tileset:addTileToBatch(batch, id, tx, ty, grid_w, grid_h, flip_x, flip_y, flip_diag)
             end
         end
     end
-    love.graphics.pop()
-    Draw.popCanvas()
 end
 
 function TileLayer:draw()
@@ -124,14 +128,13 @@ function TileLayer:draw()
 
     local grid_w, grid_h = self.map.tile_width, self.map.tile_height
 
-    Draw.setColor(1, 1, 1, a)
 
-    if a == 1 then
-        love.graphics.setBlendMode("alpha", "premultiplied")
-    else
-        love.graphics.setBlendMode("alpha")
+    Draw.pushScissor()
+    love.graphics.setScissor(0, 0, SCREEN_WIDTH, SCREEN_HEIGHT)
+    love.graphics.setBlendMode("alpha")
+    for _,batch in ipairs(self.sprite_batches) do
+        love.graphics.draw(batch)
     end
-    Draw.draw(self.canvas)
     love.graphics.setBlendMode("alpha")
 
     Draw.setColor(r, g, b, a * self.tile_opacity)
@@ -140,6 +143,7 @@ function TileLayer:draw()
     end
 
     Draw.setColor(1, 1, 1)
+    Draw.popScissor()
 
     super.draw(self)
 end

--- a/src/engine/game/world/tileset.lua
+++ b/src/engine/game/world/tileset.lua
@@ -1,5 +1,6 @@
 ---@class Tileset : Class
 ---@overload fun(...) : Tileset
+---@field quads love.Quad[]
 local Tileset = Class()
 
 Tileset.ORIGINS = {
@@ -151,7 +152,15 @@ function Tileset:drawTile(id, x, y, ...)
     end
 end
 
-function Tileset:drawGridTile(id, x, y, gw, gh, flip_x, flip_y, flip_diag)
+---@return love.Quad quad
+---@return number x
+---@return number y
+---@return number rotation_radians
+---@return number scale_x
+---@return number scale_y
+---@return number ox
+---@return number oy
+function Tileset:getGridTile(id, x, y, gw, gh, flip_x, flip_y, flip_diag)
     local draw_id = self:getDrawTile(id)
     local w, h = self:getTileSize(draw_id)
 
@@ -176,16 +185,28 @@ function Tileset:drawGridTile(id, x, y, gw, gh, flip_x, flip_y, flip_diag)
 
     local ox, oy = (w * sx) / 2, gh - (h * sy) / 2
 
+    return self.quads[draw_id], (x or 0) + ox, (y or 0) + oy, rot, flip_x and -sx or sx, flip_y and -sy or sy, w / 2, h / 2
+end
+
+function Tileset:drawGridTile(id, x, y, gw, gh, flip_x, flip_y, flip_diag)
+    local draw_id = self:getDrawTile(id)
+    local quad, draw_x, draw_y, rot, scale_x, scale_y, ox, oy = self:getGridTile(id, x, y, gw, gh, flip_x, flip_y, flip_diag)
+
     local info = self.tile_info[draw_id]
     if info and info.texture then
         if not info.quad then
-            Draw.draw(info.texture, (x or 0) + ox, (y or 0) + oy, rot, flip_x and -sx or sx, flip_y and -sy or sy, w / 2, h / 2)
+            Draw.draw(info.texture, draw_x, draw_y, rot, scale_x, scale_y, ox, oy)
         else
-            Draw.draw(info.texture, info.quad, (x or 0) + ox, (y or 0) + oy, rot, flip_x and -sx or sx, flip_y and -sy or sy, w / 2, h / 2)
+            Draw.draw(info.texture, info.quad, draw_x, draw_y, rot, scale_x, scale_y, ox, oy)
         end
     else
-        Draw.draw(self.texture, self.quads[draw_id], (x or 0) + ox, (y or 0) + oy, rot, flip_x and -sx or sx, flip_y and -sy or sy, w / 2, h / 2)
+        Draw.draw(self.texture, quad, draw_x, draw_y, rot, scale_x, scale_y, ox, oy)
     end
+end
+
+---@param batch love.SpriteBatch
+function Tileset:addTileToBatch(batch, id, x, y, gw, gh, flip_x, flip_y, flip_diag)
+    batch:add(self:getGridTile(id, x, y, gw, gh, flip_x, flip_y, flip_diag))
 end
 
 function Tileset:canDeepCopy()


### PR DESCRIPTION
Per tile layer, each tileset gets it's own sprite batch. Image collection tilesets are now treated the same as animated tiles, and so the field has been renamed to `unbatched_tiles`.