### PR TITLE
Fixed heart position in the file choicer menu (and removed broken boxes config option)

### DIFF
--- a/src/engine/menu/mainmenufileselect.lua
+++ b/src/engine/menu/mainmenufileselect.lua
@@ -54,7 +54,7 @@ function MainMenuFileSelect:onEnter(old_state)
     self.files = {}
     for i = 1, 3 do
         local data = Kristal.loadData("file_" .. i, self.mod.id)
-        local button = FileButton(self, i, data, 110, 110 + 90 * (i - 1), 422, Kristal.Config["brokenMenuBoxes"] and 82 or 78)
+        local button = FileButton(self, i, data, 110, 110 + 90 * (i - 1), 422, 78)
         if i == 1 then
             button.selected = true
         end
@@ -456,7 +456,7 @@ function MainMenuFileSelect:getHeartPos()
         local button = self:getSelectedFile()
         local hx, hy = button:getHeartPos()
         local x, y = button:getRelativePos(hx, hy)
-        return x + 9, y + (Kristal.Config["brokenMenuBoxes"] and 11 or 13)
+        return x + 9, y + 13
     elseif self.selected_y == 4 then
         return self.bottom_row_heart[self.selected_x] + 9, 390 + 9
     end

--- a/src/engine/menu/mainmenuoptions.lua
+++ b/src/engine/menu/mainmenuoptions.lua
@@ -626,15 +626,6 @@ function MainMenuOptions:initializeOptions()
 
     self:registerConfigOption("graphics", "Frame Skip", "frameSkip")
 
-    self:registerConfigOption(
-        "graphics",
-        "Broken Menu Boxes",
-        "brokenMenuBoxes",
-        function(toggled)
-            self.menu.mod_list:buildModList()
-        end
-    )
-
     ---------------------
     -- Engine Options
     ---------------------

--- a/src/engine/menu/objects/filebutton.lua
+++ b/src/engine/menu/objects/filebutton.lua
@@ -58,9 +58,9 @@ function FileButton:getHeartPos()
         return 20, self.height / 2 - 9
     else
         if self.selected_choice == 1 then
-            return 40, 52
+            return 40, 48
         else
-            return 220, 52
+            return 220, 48
         end
     end
 end

--- a/src/engine/menu/objects/modlist.lua
+++ b/src/engine/menu/objects/modlist.lua
@@ -57,10 +57,8 @@ function ModList:addMod(mod)
     table.insert(self.mods, mod)
     self.mod_container:addChild(mod)
 
-    local padding = Kristal.Config["brokenMenuBoxes"] and 4 or 6
-
-    mod:setPosition(4, self.mod_list_height + padding)
-    self.mod_list_height = self.mod_list_height + mod.height + (padding * 2)
+    mod:setPosition(4, self.mod_list_height + 6)
+    self.mod_list_height = self.mod_list_height + mod.height + (6 * 2)
     if (self.selected == 0) and (#self.mods == 1) then
         self.selected = 1
         mod:onSelect()

--- a/src/kristal.lua
+++ b/src/kristal.lua
@@ -1811,8 +1811,7 @@ function Kristal.loadConfig()
         rightStickDeadzone = 0.2,
         defaultName = "",
         skipNameEntry = false,
-        verboseLoader = false,
-        brokenMenuBoxes = false
+        verboseLoader = false
     }
     if love.filesystem.getInfo("settings.json") then
         TableUtils.merge(config, JSON.decode(love.filesystem.read("settings.json")))

--- a/src/utils/draw.lua
+++ b/src/utils/draw.lua
@@ -509,13 +509,11 @@ function Draw.drawMenuRectangle(x, y, width, height)
     love.graphics.setLineWidth(1)
     love.graphics.setLineStyle("rough")
 
-    local extra = Kristal.Config["brokenMenuBoxes"] and 0 or 1
-
     -- Draw the rectangles
     love.graphics.rectangle("line", x, y, width + 1, height + 1)
-    love.graphics.rectangle("line", x - 1, y - 1, width + 2 + extra, height + 2 + extra)
+    love.graphics.rectangle("line", x - 1, y - 1, width + 3, height + 3)
     love.graphics.rectangle("line", x - 2, y - 2, width + 5, height + 5)
-    love.graphics.rectangle("line", x - 3, y - 3, width + 6 + extra, height + 6 + extra)
+    love.graphics.rectangle("line", x - 3, y - 3, width + 7, height + 7)
 end
 
 return Draw


### PR DESCRIPTION
The heart was 4 pixels lower than in DR.

The broken boxes are no longer a thing in DR, and Ally planned on removing the config option anyway.

<img width="1897" height="739" alt="image" src="https://github.com/user-attachments/assets/8f3ba030-f410-4244-93a1-510042083a93" />
