### PR TITLE
Fixed Playstation Button Layout not displaying

### DIFF
--- a/src/engine/input.lua
+++ b/src/engine/input.lua
@@ -1054,7 +1054,7 @@ function Input.getControllerType()
     if con("nintendo") or con("switch") or con("joy-con") or con("wii") or con("gamecube") or con("nso") or con("nes") then
         return "switch"
     end
-    if con("sony") or con("playstation") or con("%f[%a]ps") or con("dualshock") or con("dualsense") or con("dualforce") then
+    if con("sony") or con("playstation") or con("ps") or con("dualshock") or con("dualsense") or con("dualforce") then
         return "ps4"
     end
     return "xbox"


### PR DESCRIPTION
Kristal didn't recognized my Playstation 4 controller (Dualshock 4) as a Playstation controller.

Love2D called it "PS4 Controller", and for some reason, the check for it was "%f[%a]ps" instead of just "ps".

<img width="3840" height="2160" alt="Screenshot (388)" src="https://github.com/user-attachments/assets/683cc4b4-4b59-4fd1-84e5-5cb48bdc6f15" />
