### PR TITLE
Game state system rewrite

### DIFF
--- a/main.lua
+++ b/main.lua
@@ -146,6 +146,8 @@ Choicebox = require("src.engine.game.common.choicebox")
 TextChoicebox = require("src.engine.game.common.textchoicebox")
 SmallFaceText = require("src.engine.game.common.smallfacetext")
 
+GameState = require("src.engine.game.gamestate")
+
 World = require("src.engine.game.world")
 Map = require("src.engine.game.world.map")
 Tileset = require("src.engine.game.world.tileset")

--- a/src/engine/game/battle.lua
+++ b/src/engine/game/battle.lua
@@ -1,7 +1,7 @@
 --- The `Battle` Object manages everything related to battles in Kristal. \
 --- A globally available reference to the in-use `Battle` instance is stored in [`Game.battle`](lua://Game.battle).
 ---
----@class Battle : Object
+---@class Battle : GameState
 ---
 ---@field party                     PartyBattler[]                  A table of all the [PartyBattler](lua://PartyBattler)s in the current battle
 ---
@@ -62,7 +62,7 @@
 ---@field transitioned              boolean                         Whether the battle opened with a transition *(only set during `postInit()`)*
 ---
 ---@overload fun(...) : Battle
-local Battle, super = Class(Object)
+local Battle, super = Class(GameState)
 
 ---@alias BattleState # The state of the battle.
 ---| "NONE" # An empty state which does nothing.
@@ -138,8 +138,6 @@ function Battle:init()
 
     self.arena = nil
     self.soul = nil
-
-    self.music = Music()
 
     self.resume_world_music = false
 
@@ -217,6 +215,14 @@ function Battle:init()
     self.defending_begin_timer = 0
 end
 
+function Battle:getLegacyGameStateID()
+    return "BATTLE"
+end
+
+function Battle:isMusicActive()
+    return self.encounter.music ~= nil
+end
+
 function Battle:createPartyBattlers()
     for i = 1, math.min(3, #Game.party) do
         local party_member = Game.party[i]
@@ -273,11 +279,6 @@ function Battle:postInit(state, encounter)
     end
 
     self.background = self.encounter:createBackground()
-
-    if Game.world.music:isPlaying() and self.encounter.music then
-        self.resume_world_music = true
-        Game.world.music:pause()
-    end
 
     if self.encounter.queued_enemy_spawns then
         for _, enemy in ipairs(self.encounter.queued_enemy_spawns) do
@@ -374,8 +375,6 @@ end
 ---@param parent Object
 function Battle:onRemove(parent)
     super.onRemove(self, parent)
-
-    self.music:remove()
 end
 
 --- Changes the state of the battle and calls [onStateChange()](lua://Battle.onStateChange)
@@ -2491,6 +2490,10 @@ end
 
 --- Ends the battle and removes itself from `Game.battle`
 function Battle:returnToWorld()
+    Game:popState()
+end
+
+function Battle:onExit()
     if not Game:getConfig("keepTensionAfterBattle") then
         Game:setTension(0)
     end
@@ -2528,10 +2531,8 @@ function Battle:returnToWorld()
     if self.resume_world_music then
         Game.world.music:resume()
     end
-    self:remove()
-    self.encounter.defeated_enemies = self.defeated_enemies
     Game.battle = nil
-    Game.state = "OVERWORLD"
+    self.encounter.defeated_enemies = self.defeated_enemies
 end
 
 ---@param text          string|string[]
@@ -3045,6 +3046,10 @@ function Battle:isWorldHidden()
     return self.state ~= "TRANSITION" and
         self.state ~= "TRANSITIONOUT" and
         (self.encounter.background or self.encounter.hide_world)
+end
+
+function Battle:shouldHideOtherStates()
+    return self:isWorldHidden()
 end
 
 ---@param menu_item table

--- a/src/engine/game/game.lua
+++ b/src/engine/game/game.lua
@@ -48,6 +48,7 @@
 local Game = {}
 
 function Game:clear()
+    self:clearStateStack()
     if self.world and self.world.music then
         self.world.music:stop()
     end
@@ -74,6 +75,15 @@ function Game:clear()
     self.key_repeat = false
     self.started = false
     self.border = "simple"
+end
+
+function Game:clearStateStack()
+    if self.states ~= nil then
+        for i = #self.states, 1, -1 do
+            self.states[i]:exit()
+        end
+    end
+    self.states = {}
 end
 
 ---@overload fun(self: Game, previous_state: string, save_data: SaveData, save_id: number)
@@ -271,19 +281,8 @@ end
 
 ---@return Music
 function Game:getActiveMusic()
-    if self.state == "OVERWORLD" then
-        return self.world.music
-    elseif self.state == "BATTLE" then
-        return self.battle.music
-    elseif self.state == "SHOP" then
-        return self.shop.music
-    elseif self.state == "GAMEOVER" then
-        return self.gameover.music
-    elseif self.state == "LEGEND" then
-        return self.legend.music
-    else
-        return self.music
-    end
+    local mus_state = self:getMusicState()
+    return mus_state and mus_state:getMusic() or self.music
 end
 
 ---@return {name: string, level: integer, playtime: number, room_name: string}
@@ -390,7 +389,7 @@ function Game:load(data, index, fade)
     self.stage = Stage()
 
     self.world = World()
-    self.stage:addChild(self.world)
+    self:pushState(self.world)
 
     self.fader = Fader()
     self.fader.layer = 1000
@@ -673,14 +672,9 @@ function Game:gameOver(x, y)
     end
     Kristal.hideBorder(0)
 
-    self.state = "GAMEOVER"
-
-    for _, child in ipairs(self.stage.children) do
-        child:remove()
-    end
-
+    self:clearStateStack()
     self.gameover = GameOver(x, y)
-    self.stage:addChild(self.gameover)
+    self:pushState(self.gameover)
 end
 
 ---@param cutscene          string
@@ -705,9 +699,8 @@ function Game:startLegend(cutscene, options)
         self.legend:remove()
     end
 
-    self.state = "LEGEND"
     self.legend = Legend(cutscene, options)
-    self.stage:addChild(self.legend)
+    self:pushState(self.legend)
 end
 
 ---@param ... unknown
@@ -757,8 +750,7 @@ function Game:encounter(encounter, transition, enemy, context)
     else
         self.battle:postInit(transition and "TRANSITION" or "INTRO", encounter)
     end
-
-    self.stage:addChild(self.battle)
+    self:pushState(self.battle)
 end
 
 ---@param shop string|Shop
@@ -800,8 +792,7 @@ function Game:enterShop(shop, options)
 
     self.state = "SHOP"
 
-    self.stage:addChild(self.shop)
-    self.shop:onEnter()
+    self:pushState(self.shop)
 end
 
 --- Sets the value of the flag named `flag` to `value`
@@ -1158,14 +1149,12 @@ function Game:update()
         return
     end
 
-    if self.world then
-        if self:isWorldHidden() then
-            self.world.active = false
-            self.world.visible = false
-        else
-            self.world.active = true
-            self.world.visible = true
-        end
+    local visible = true
+    for i = #self.states, 1, -1 do
+        local state = self.states[i]
+        state.visible = visible
+        state.active = visible
+        visible = visible and not state:shouldHideOtherStates()
     end
 
     self.playtime = self.playtime + DT
@@ -1182,25 +1171,24 @@ function Game:onKeyPressed(key, is_repeat)
         -- Mod:onKeyPressed returned true, cancel default behaviour
         return
     end
+    if Kristal.isDevMode() and Input.ctrl() then
+        if key == "m" then
+            local music = self:getActiveMusic()
+            if music:isPlaying() then
+                music:pause()
+            else
+                music:resume()
+            end
+            return
+        end
+    end
 
     if is_repeat and not self.key_repeat then
         -- Ignore key repeat unless enabled by a game state
         return
     end
 
-    if self.state == "BATTLE" then
-        if self.battle then
-            self.battle:onKeyPressed(key)
-        end
-    elseif self.state == "OVERWORLD" then
-        if self.world then
-            self.world:onKeyPressed(key)
-        end
-    elseif self.state == "GAMEOVER" then
-        if self.gameover then
-            self.gameover:onKeyPressed(key)
-        end
-    end
+    self:getCurrentState():onKeyPressed(key, is_repeat)
 end
 
 ---@param key string
@@ -1249,6 +1237,64 @@ function Game:draw()
     love.graphics.pop()
 
     self:drawDevWarning()
+end
+
+---@generic T: GameState|World|Shop|GameOver
+---@param state T
+---@return T
+function Game:getState(state)
+    if not (isClass(state) and state:includes(GameState)) then
+        error("Expected a GameState class to Game:getState")
+    end
+    for i = #self.states, 1, -1 do
+        local this_state = self.states[i]
+        if this_state:includes(state) then
+            return this_state
+        end
+    end
+    error("Unable to find desired state")
+end
+
+---@return GameState
+function Game:getCurrentState()
+    return self.states[#self.states]
+end
+
+---@private
+function Game:getMusicState()
+    for i = #self.states, 1, -1 do
+        local state = self.states[i] ---@type GameState
+        if state:isMusicActive() then
+            return state
+        end
+    end
+end
+
+---@param state GameState
+function Game:pushState(state)
+    self.stage:addChild(state)
+    if #self.states > 0 and state:isMusicActive() then
+        local old_state = self:getMusicState()
+        if old_state then
+            old_state.was_music_playing = old_state:getMusic():isPlaying()
+            old_state:getMusic():pause()
+        end
+    end
+    table.insert(self.states, state)
+    self.state = self:getCurrentState():getLegacyGameStateID()
+    state:enter()
+end
+
+function Game:popState()
+    local popped_state = table.remove(self.states, #self.states)
+    popped_state:exit()
+    self.stage:removeChild(popped_state)
+    local new_state = self:getCurrentState()
+    self.state = new_state:getLegacyGameStateID()
+    local mus_state = self:getMusicState()
+    if mus_state and mus_state.was_music_playing then
+        mus_state:getMusic():resume()
+    end
 end
 
 return Game

--- a/src/engine/game/game.lua
+++ b/src/engine/game/game.lua
@@ -1241,12 +1241,12 @@ function Game:draw()
     self:drawDevWarning()
 end
 
----@generic T: GameState|World|Shop|GameOver
+---@generic T: GameState
 ---@param state T
 ---@return T
 function Game:getState(state)
     if not (isClass(state) and state:includes(GameState)) then
-        error("Expected a GameState class to Game:getState")
+        error("Expected a GameState class as argument to Game:getState")
     end
     for i = #self.state_stack, 1, -1 do
         local this_state = self.state_stack[i]

--- a/src/engine/game/game.lua
+++ b/src/engine/game/game.lua
@@ -39,6 +39,7 @@
 ---@field party             PartyMember[]
 ---@field party_data        PartyMember[]
 ---@field recruits_data     Recruit[]
+---@field private state_stack GameState[]
 ---
 ---@field fader             Fader
 ---@field max_followers     integer
@@ -78,12 +79,13 @@ function Game:clear()
 end
 
 function Game:clearStateStack()
-    if self.states ~= nil then
-        for i = #self.states, 1, -1 do
-            self.states[i]:exit()
+    if self.state_stack ~= nil then
+        for i = #self.state_stack, 1, -1 do
+            self.state_stack[i]:remove()
+            self.state_stack[i]:exit()
         end
     end
-    self.states = {}
+    self.state_stack = {}
 end
 
 ---@overload fun(self: Game, previous_state: string, save_data: SaveData, save_id: number)
@@ -1150,8 +1152,8 @@ function Game:update()
     end
 
     local visible = true
-    for i = #self.states, 1, -1 do
-        local state = self.states[i]
+    for i = #self.state_stack, 1, -1 do
+        local state = self.state_stack[i]
         state.visible = visible
         state.active = visible
         visible = visible and not state:shouldHideOtherStates()
@@ -1246,8 +1248,8 @@ function Game:getState(state)
     if not (isClass(state) and state:includes(GameState)) then
         error("Expected a GameState class to Game:getState")
     end
-    for i = #self.states, 1, -1 do
-        local this_state = self.states[i]
+    for i = #self.state_stack, 1, -1 do
+        local this_state = self.state_stack[i]
         if this_state:includes(state) then
             return this_state
         end
@@ -1257,13 +1259,13 @@ end
 
 ---@return GameState
 function Game:getCurrentState()
-    return self.states[#self.states]
+    return self.state_stack[#self.state_stack]
 end
 
 ---@private
 function Game:getMusicState()
-    for i = #self.states, 1, -1 do
-        local state = self.states[i] ---@type GameState
+    for i = #self.state_stack, 1, -1 do
+        local state = self.state_stack[i] ---@type GameState
         if state:isMusicActive() then
             return state
         end
@@ -1273,20 +1275,20 @@ end
 ---@param state GameState
 function Game:pushState(state)
     self.stage:addChild(state)
-    if #self.states > 0 and state:isMusicActive() then
+    if #self.state_stack > 0 and state:isMusicActive() then
         local old_state = self:getMusicState()
         if old_state then
             old_state.was_music_playing = old_state:getMusic():isPlaying()
             old_state:getMusic():pause()
         end
     end
-    table.insert(self.states, state)
+    table.insert(self.state_stack, state)
     self.state = self:getCurrentState():getLegacyGameStateID()
     state:enter()
 end
 
 function Game:popState()
-    local popped_state = table.remove(self.states, #self.states)
+    local popped_state = table.remove(self.state_stack, #self.state_stack)
     popped_state:exit()
     self.stage:removeChild(popped_state)
     local new_state = self:getCurrentState()

--- a/src/engine/game/gameover.lua
+++ b/src/engine/game/gameover.lua
@@ -1,8 +1,8 @@
 --- An object that is created whenever the player reaches a Game Over, responsible for managing the GameOver sequence. \
 --- The type of GameOver that plays (Chapter 1, Chapter 2, or Undertale) is dependent on the project configuration and whether the death occurred in the Light World or not.
----@class GameOver : Object
+---@class GameOver : GameState
 ---@overload fun(...) : GameOver
-local GameOver, super = Class(Object, "gameover")
+local GameOver, super = Class(GameState, "gameover")
 
 function GameOver:init(x, y)
     super.init(self, 0, 0)
@@ -34,6 +34,10 @@ function GameOver:init(x, y)
     if Game:isLight() then
         self.timer = 28 -- We only wanna show one frame if we're in Undertale mode
     end
+end
+
+function GameOver:getLegacyGameStateID()
+    return "GAMEOVER"
 end
 
 function GameOver:onRemove(parent)

--- a/src/engine/game/gameover.lua
+++ b/src/engine/game/gameover.lua
@@ -14,8 +14,6 @@ function GameOver:init(x, y)
         self.screenshot = love.graphics.newImage(SCREEN_CANVAS:newImageData())
     end
 
-    self.music = Music()
-
     self.soul = Sprite("player/heart")
     self.soul:setOrigin(0.5, 0.5)
     self.soul:setColor(Game:getSoulColor())

--- a/src/engine/game/gamestate.lua
+++ b/src/engine/game/gamestate.lua
@@ -1,0 +1,53 @@
+---@class GameState: Object
+---@field music Music
+local GameState, super = Class(Object)
+
+function GameState:enter()
+    -- Prevent memory leak in case Music is created in init
+    if self.music ~= nil then
+        self.music:remove()
+    end
+    self.music = Music()
+    self:onEnter()
+end
+
+---@protected
+function GameState:onEnter() end
+
+function GameState:exit()
+    self.music:remove()
+    self:onExit()
+end
+
+---@protected
+function GameState:onExit() end
+
+function GameState:shouldHideOtherStates()
+    return false
+end
+
+-- *Override* Called when a keyboard key or gamepad button is pressed while
+-- this state is active.
+function GameState:onKeyPressed(key, is_repeat) end
+
+-- *Called internally* Used to set the Game.state field for states made prior
+-- to the introduction of the GameState parent class. You shouldn't need to
+-- override this.
+function GameState:getLegacyGameStateID()
+    return "CUSTOM"
+end
+
+-- *Override* Checks if this state's music is considered "active". If not,
+-- Game:getActiveMusic() will fall back to the next state in the stack.
+-- Result is assumed to remain consistent throughout the lifetime of the object.
+---@return boolean
+function GameState:isMusicActive()
+    return false
+end
+
+function GameState:getMusic()
+    return self.music
+end
+
+return GameState
+

--- a/src/engine/game/gamestate.lua
+++ b/src/engine/game/gamestate.lua
@@ -23,7 +23,8 @@ function GameState:shouldHideOtherStates()
 end
 
 -- *Override* Called when a keyboard key or gamepad button is pressed while
--- this state is active.
+-- this state is active. Note that it's generally preferred to check for
+-- inputs in `update`, rather than overriding this method.
 function GameState:onKeyPressed(key, is_repeat) end
 
 -- *Called internally* Used to set the Game.state field for states made prior

--- a/src/engine/game/gamestate.lua
+++ b/src/engine/game/gamestate.lua
@@ -3,10 +3,6 @@
 local GameState, super = Class(Object)
 
 function GameState:enter()
-    -- Prevent memory leak in case Music is created in init
-    if self.music ~= nil then
-        self.music:remove()
-    end
     self.music = Music()
     self:onEnter()
 end

--- a/src/engine/game/legend.lua
+++ b/src/engine/game/legend.lua
@@ -9,6 +9,8 @@ local Legend, super = Class(GameState, "legend")
 function Legend:init(cutscene, options)
     super.init(self, 0, 0)
 
+    self.music = Music()
+
     options = options or {}
 
     self.can_skip = options["can_skip"] or false
@@ -51,6 +53,11 @@ end
 
 function Legend:shouldHideOtherStates()
     return true
+end
+
+function Legend:enter()
+    -- Don't create a `Music` instance since that's done in `init`
+    self:onEnter()
 end
 
 function Legend:onEnter()

--- a/src/engine/game/legend.lua
+++ b/src/engine/game/legend.lua
@@ -1,9 +1,11 @@
 --- The handler object for Legend-style cutscenes. \
 --- For the object that is received by legend cutscene scripts, see [`LegendCutscene`](lua://LegendCutscene.init).
----@class Legend : Object
+---@class Legend : GameState
 ---@overload fun(...) : Legend
-local Legend, super = Class(Object, "legend")
+local Legend, super = Class(GameState, "legend")
 
+---@param cutscene LegendCutscene
+---@param options table
 function Legend:init(cutscene, options)
     super.init(self, 0, 0)
 
@@ -11,8 +13,11 @@ function Legend:init(cutscene, options)
 
     self.can_skip = options["can_skip"] or false
     self.cutscene = cutscene
-
-    self.music = Music(options["music"], options["music_volume"] or 1, options["music_pitch"] or 1)
+    self.music_options = {
+        name = options["music"] --[[@as string?]],
+        volume = options["music_volume"] or 1,
+        pitch = options["music_pitch"] or 1,
+    }
     if self.music.source then
         self.music.source:setLooping(true)
     end
@@ -44,9 +49,18 @@ function Legend:init(cutscene, options)
     self.slides = {}
 end
 
+function Legend:shouldHideOtherStates()
+    return true
+end
+
+function Legend:onEnter()
+    if self.music_options.name ~= nil then
+        self.music:play(self.music_options.name, self.music_options.volume, self.music_options.pitch)
+    end
+end
+
 function Legend:onFinish(skip)
-    self:remove()
-    Game.state = "OVERWORLD"
+    Game:popState()
     Game.world.fader:fadeIn(
         function()
             if not Game.world:hasCutscene() then
@@ -65,8 +79,6 @@ end
 
 function Legend:onRemove(parent)
     super.onRemove(self, parent)
-
-    self.music:remove()
 end
 
 

--- a/src/engine/game/legend.lua
+++ b/src/engine/game/legend.lua
@@ -52,7 +52,12 @@ function Legend:init(cutscene, options)
 end
 
 function Legend:shouldHideOtherStates()
-    return true
+    -- Some projects rely on the world updating for playing legends during world cutscenes.
+    return false
+end
+
+function Legend:getLegacyGameStateID()
+    return "LEGEND"
 end
 
 function Legend:enter()

--- a/src/engine/game/shop.lua
+++ b/src/engine/game/shop.lua
@@ -2,7 +2,7 @@
 --- Shop files should be located in `scripts/shops`, and will use their filepath relative to this location as an id by default. \
 --- Either [`World:shopTransition()`](lua://World.shopTransition) or a [`Transition`](lua://Transition) event with the property `shop` defined can be used to enter shops. 
 ---
----@class Shop : Object
+---@class Shop : GameState
 ---@overload fun(...) : Shop
 ---
 --- The label used for currency in this shop.
@@ -105,7 +105,7 @@
 ---@field private current_selected_main_option integer The current selected menu option in the MAINMENU state.
 ---@field private current_selecting_storage integer The current selected item storage index in the SELLMENU state.
 ---
-local Shop, super = Class(Object, "shop")
+local Shop, super = Class(GameState, "shop")
 
 ---@alias ShopState
 ---| "MAINMENU"    # The state used when the player is in the Main menu.
@@ -190,7 +190,6 @@ function Shop:init()
     self.state_reason = nil
 
     self.shop_music = ""
-    self.music = Music()
 
     self.timer = Timer()
     self:addChild(self.timer)
@@ -243,6 +242,10 @@ function Shop:init()
 
     self.hide_world = true
     self.hide_main_menu_currency = false
+end
+
+function Shop:getLegacyGameStateID()
+    return "SHOP"
 end
 
 --- A function that runs later than `Shop:init()`, primarily setting up UI elements of the shop. \
@@ -362,8 +365,10 @@ end
 ---@param parent Object
 function Shop:onRemove(parent)
     super.onRemove(self, parent)
+end
 
-    self.music:remove()
+function Shop:isMusicActive()
+    return self.shop_music ~= nil
 end
 
 ---@return string
@@ -658,14 +663,14 @@ end
 
 --- Leaves the shop instantly, without a transition.
 function Shop:leaveImmediate()
-    self:remove()
-    Game.shop = nil
-    Game.state = "OVERWORLD"
+    Game:popState()
+end
+
+function Shop:onExit()
     if self:shouldFade() then
         Game.fader.alpha = 1
         Game.fader:fadeIn()
     end
-    Game.world:setState("GAMEPLAY")
 
     --self.transition_target.shop = nil
     --Game.world:transitionImmediate(self.transition_target)
@@ -679,8 +684,8 @@ function Shop:leaveImmediate()
         if self.leave_options["facing"] then
             Game.world.player:setFacing(self.leave_options["facing"])
         end
-        Game.world.music:resume()
     end
+    Game.shop = nil
 end
 
 function Shop:shouldFade()
@@ -1708,6 +1713,10 @@ end
 ---@return boolean Whether the world is hidden.
 function Shop:isWorldHidden()
     return self.hide_world
+end
+
+function Shop:shouldHideOtherStates()
+    return self:isWorldHidden()
 end
 
 --- *(Override)* Returns whether the shop should hide the currency while in the MAINMENU state.

--- a/src/engine/game/world.lua
+++ b/src/engine/game/world.lua
@@ -6,8 +6,6 @@
 ---@field state             string                          The current state that this `World` is in - should never be set manually, see [`World:setState()`](lua://World.setState) instead
 ---@field state_manager     StateManager                    An object that manages the state of this `World`
 ---
----@field music             Music                           The `Music` instance that controls audio playback for this `World`
----
 ---@field map               Map                             The currently loaded map instance
 ---
 ---@field camera            Camera                          The camera object used to display the world

--- a/src/engine/game/world.lua
+++ b/src/engine/game/world.lua
@@ -1,7 +1,7 @@
 --- The `World` Object manages everything relating to the overworld in Kristal. \
 --- A globally available instance of `World` is stored in [`Game.world`](lua://Game.world).
 ---
----@class World : Object, StateManagedClass
+---@class World : GameState, StateManagedClass
 ---
 ---@field state             string                          The current state that this `World` is in - should never be set manually, see [`World:setState()`](lua://World.setState) instead
 ---@field state_manager     StateManager                    An object that manages the state of this `World`
@@ -47,7 +47,7 @@
 ---@field healthbar         HealthBar
 ---
 ---@overload fun(map?: string) : World
-local World, super = Class(Object)
+local World, super = Class(GameState, "World")
 
 ---@param map? string    The optional name of a map to initially load with the world
 function World:init(map)
@@ -59,8 +59,6 @@ function World:init(map)
     self.state_manager:addState("GAMEPLAY")
     self.state_manager:addState("FADING")
     self.state_manager:addState("MENU")
-
-    self.music = Music()
 
     self.map = Map(self)
 
@@ -116,6 +114,10 @@ function World:init(map)
     if map then
         self:loadMap(map)
     end
+end
+
+function World:getLegacyGameStateID()
+    return "OVERWORLD"
 end
 
 --- Heals a member of the party
@@ -1226,8 +1228,10 @@ end
 ---@param parent Object
 function World:onRemove(parent)
     super.onRemove(self, parent)
+end
 
-    self.music:remove()
+function World:isMusicActive()
+    return true
 end
 
 --- Sets whether the player is currently in battle - cannot override being inside a battle area


### PR DESCRIPTION
Adds a stack-based system for game substates (World, Battle, Shop, etc.). All states inherit from the GameState object. States are pushed with Game:pushState(state), and popped with Game:popState(). The `Game.state` field is set based on the result of the state's getLegacyGameStateID method (which, aside from pre-existing states adapted for the new system, shouldn't be overwritten). You can get a reference to the current state with `Game:getCurrentState()`, or to a specific state with `Game:getState(state_class)` (will error if specified state isn't in the stack). Fields such as `Game.battle` will still be set as before.