### PR TITLE
More accurate Chapter 5 config

### DIFF
--- a/configs/chapter5.json
+++ b/configs/chapter5.json
@@ -29,9 +29,9 @@
     "mercyMessages": true,           // "+X%" mercy messages
     "mercyBar": true,                // Mercy bar next to hp bar in enemy select
     "enemyBarPercentages": true,     // HP / Mercy bar percentages
-    "pacifyGlow": true,              // Pacify (and other spells) glow when enemies are TIRED
+    "pacifyGlow": false,             // Pacify (and other spells) glow when enemies are TIRED
     "tiredMessages": true,           // Tired mercy messages
-    "awakeMessages": true,           // Awake un-mercy messages
+    "awakeMessages": false,          // Awake un-mercy messages
     "checkActDescription": true,     // Whether the "Check" act in battle says "Useless analysis" or not
 
     "targetSystem": false,           // Whether the target system should be used or not

--- a/src/engine/menu/mainmenumodconfig.lua
+++ b/src/engine/menu/mainmenumodconfig.lua
@@ -202,7 +202,7 @@ end
 function MainMenuModConfig:registerOptions()
     self.options = {}
 
-    self:registerOption("storageSlots", "Storage Slots", "The amount of storage slots in the dark world inventory", "selection", { nil, 0, 12, 24, 36 }) -- unhardcode
+    self:registerOption("storageSlots", "Storage Slots", "The amount of storage slots in the dark world inventory", "selection", { nil, 0, 12, 24, 36, 48 }) -- unhardcode
     self:registerOption("enableRecruits", "Enable Recruits", "Enable recruit messages and menu", "selection", { nil, true, false })
     self:registerOption("recruitsProgressSpaces", "Recruits Progress Spaces", "Whether the recruits progress in the menu will have spaces between the amounts", "selection", { nil, true, false })
     self:registerOption("smallSaveMenu", "Small Save Menu", "Single-file save menu with no storage/recruits options", "selection", { nil, true, false })


### PR DESCRIPTION
The glow of pacifying spells is absent from Chapter 5, as well as any signs of "Awake" message. Also, added the Chapter 5 storage slot amount to the project creation config.