### PR TITLE
Move logic for config saving outside of Kristal.setVolume

### DIFF
--- a/src/engine/game/world/ui/dark/config/darkconfigvolumestate.lua
+++ b/src/engine/game/world/ui/dark/config/darkconfigvolumestate.lua
@@ -26,6 +26,8 @@ function DarkConfigVolumeState:onUpdate()
     if Input.pressed("cancel") or Input.pressed("confirm") then
         Kristal.setVolume(MathUtils.round(Kristal.getVolume() * 100) / 100)
 
+        Kristal.saveConfig()
+        
         Assets.stopAndPlaySound("ui_select")
 
         self.menu:setState("MAIN")

--- a/src/engine/menu/mainmenucredits.lua
+++ b/src/engine/menu/mainmenucredits.lua
@@ -90,7 +90,8 @@ function MainMenuCredits:init(menu)
                 { "GitHub Contributors", COLORS.silver },
                 "WIL-TZY",
                 "YeetusSnoopy",
-                "Maks7594"
+                "Maks7594",
+                "NakuAutumn/GoldofLeaves/GoldenLeaf"
             }
         }
     }

--- a/src/engine/menu/mainmenucredits.lua
+++ b/src/engine/menu/mainmenucredits.lua
@@ -91,7 +91,7 @@ function MainMenuCredits:init(menu)
                 "WIL-TZY",
                 "YeetusSnoopy",
                 "Maks7594",
-                "NakuAutumn/GoldofLeaves/GoldenLeaf"
+                "NakuAutumn"
             }
         }
     }

--- a/src/engine/menu/mainmenuoptions.lua
+++ b/src/engine/menu/mainmenuoptions.lua
@@ -291,6 +291,8 @@ function MainMenuOptions:onKeyPressedVolume(key, is_repeat)
     if Input.isCancel(key) or Input.isConfirm(key) then
         Kristal.setVolume(MathUtils.round(Kristal.getVolume() * 100) / 100)
 
+        Kristal.saveConfig()
+
         Assets.stopAndPlaySound("ui_select")
         self:setState("MENU")
     end

--- a/src/kristal.lua
+++ b/src/kristal.lua
@@ -1181,7 +1181,6 @@ end
 function Kristal.setVolume(volume)
     Kristal.Config["masterVolume"] = MathUtils.clamp(volume, 0, 1)
     love.audio.setVolume(volume)
-    Kristal.saveConfig()
 end
 
 --- Called internally to make sure the correct cursor is displayed.


### PR DESCRIPTION
When editing the master volume, Kristal.setVolume is called every frame, since the logic for config saving is inside Kristal.setVolume, this causes a performance cause the program is writing a to json file every frame.
This pr moves the config saving logic to when the volume is finished setting so it is only called once.