### PR TITLE
add specific portrait/miniface offsets

### DIFF
--- a/src/engine/game/common/data/actor.lua
+++ b/src/engine/game/common/data/actor.lua
@@ -49,10 +49,14 @@ function Actor:init()
     self.portrait_path = nil
     -- Offset position for this actor's portrait (optional)
     self.portrait_offset = nil
+    -- Specific offsets for portraits (optional)
+    self.portrait_offsets = {}
     -- Path to this actor's miniface for dialogue (optional)
     self.miniface = nil
     -- Offset position for this actor's miniface (optional)
     self.miniface_offset = nil
+    -- Specific offset position for this actor's miniface (optional)
+    self.miniface_offsets = {}
 
     -- Whether this actor as a follower will blush when close to the player
     self.can_blush = false
@@ -151,8 +155,10 @@ function Actor:getIndentString() return self.indent_string end
 
 function Actor:getPortraitPath() return self.portrait_path end
 function Actor:getPortraitOffset() return unpack(self.portrait_offset or { 0, 0 }) end
+function Actor:getSpecificPortraitOffset(portrait_name) return unpack(self.portrait_offsets[portrait_name] or {0, 0}) end
 function Actor:getMiniface() return self.miniface end
 function Actor:getMinifaceOffset() return unpack(self.miniface_offset or { 0, 0 }) end
+function Actor:getSpecificMinifaceOffset(portrait_name) return unpack(self.miniface_offsets[portrait_name] or {0, 0}) end
 
 function Actor:getFlipDirection(sprite) return self.flip or self.flip_sprites[sprite] end
 

--- a/src/engine/game/common/textbox.lua
+++ b/src/engine/game/common/textbox.lua
@@ -144,8 +144,9 @@ function Textbox:init(x, y, width, height, default_font, default_font_size, batt
         local oy = tonumber(node.arguments[3]) or 0
         if self.actor then
             local actor_ox, actor_oy = self.actor:getMinifaceOffset()
-            ox = actor_ox
-            oy = actor_oy
+            local miniface_ox, miniface_oy = self.actor:getSpecificMinifaceOffset(node.arguments[1])
+            ox = ox + actor_ox + miniface_ox
+            oy = oy + actor_oy + miniface_oy
         end
         local x_scale = tonumber(node.arguments[4]) or 2
         local y_scale = tonumber(node.arguments[5]) or 2
@@ -228,8 +229,9 @@ function Textbox:setFace(face, ox, oy)
 
     if self.actor then
         local actor_ox, actor_oy = self.actor:getPortraitOffset()
-        ox = (ox or 0) + actor_ox
-        oy = (oy or 0) + actor_oy
+        local face_ox, face_oy = self.actor:getSpecificPortraitOffset(face)
+        ox = (ox or 0) + actor_ox + face_ox
+        oy = (oy or 0) + actor_oy + face_oy
     end
     self.face:setPosition(self.face_x + (ox or 0), self.face_y + (oy or 0))
 


### PR DESCRIPTION
added the ability to offset a character's specific portrait (or miniface) as a table. this offset is superimposed on the already-existing portrait_offset, which offsets all portraits normally.

also fixed a minor quirk in the miniface offset where the passed offset was ignored in the text command if the actor had specified its own miniface offset