### PR TITLE
Fixed `self.last_x` being incorrectly set to `self.y` in `Object.lua`.

### DIFF
--- a/src/engine/object.lua
+++ b/src/engine/object.lua
@@ -190,7 +190,7 @@ function Object:init(x, y, width, height)
 
     -- Save the previous position
     self.last_x = self.x
-    self.last_x = self.y
+    self.last_y = self.y
 
     -- Initialize this object's size
     self.width = width or 0


### PR DESCRIPTION
As the title states, this is a fix for a small oversight in `Object:init()` where `self.last_x` was set to both `self.x` & `self.y`. It has been corrected so that `self.last_x = self.x` & `self.last_y = self.y`. 

(Think I explained that correctly lol.)