### PR TITLE
Collider restructuring, bounding box checks

### DIFF
--- a/main.lua
+++ b/main.lua
@@ -116,6 +116,8 @@ FountainShadowFX = require("src.engine.drawfx.fountainshadowfx")
 GradientFX = require("src.engine.drawfx.gradientfx")
 ScissorFX = require("src.engine.drawfx.scissorfx")
 
+CollisionRegistry = require("src.engine.colliders.collisionregistry")
+KristalCollisions = require("src.engine.colliders.kristalcollisions")
 Collider = require("src.engine.colliders.collider")
 ColliderGroup = require("src.engine.colliders.collidergroup")
 Hitbox = require("src.engine.colliders.hitbox")

--- a/src/engine/colliders/circlecollider.lua
+++ b/src/engine/colliders/circlecollider.lua
@@ -23,6 +23,10 @@ function CircleCollider:getColliderType()
     return CollisionRegistry.CIRCLE
 end
 
+function CircleCollider:getBounds()
+    return self.x - self.radius, self.y - self.radius, self.radius * 2, self.radius * 2
+end
+
 --- Gets the circle's center and radius.
 ---@return number x # The X coordinate of the circle's center.
 ---@return number y # The Y coordinate of the circle's center.
@@ -53,15 +57,6 @@ function CircleCollider:getCircleFor(other)
     local crx, cry = other:getLocalPoint(tf1, tf2, self.x + self.radius, self.y)
 
     return cx, cy, MathUtils.dist(cx, cy, crx, cry)
-end
-
---- Gets the axis-aligned bounding box of the circle.
----@return number x # The X coordinate of the bounding box.
----@return number y # The Y coordinate of the bounding box.
----@return number width # The width of the bounding box.
----@return number height # The height of the bounding box.
-function CircleCollider:getBounds()
-    return self.x - self.radius, self.y - self.radius, self.radius * 2, self.radius * 2
 end
 
 --- Draws the circle outlined with the given color.

--- a/src/engine/colliders/circlecollider.lua
+++ b/src/engine/colliders/circlecollider.lua
@@ -1,64 +1,52 @@
+--- A circular collider used for collision detection.
 ---@class CircleCollider : Collider
----@overload fun(...) : CircleCollider
+---@field x number # The X coordinate of the circle's center.
+---@field y number # The Y coordinate of the circle's center.
+---@field radius number # The radius of the circle.
+---@overload fun(owner: Object?, x: number, y: number, radius: number, mode: Collider.Mode?) : CircleCollider
 local CircleCollider, super = Class(Collider)
 
----@param parent any
+---@param owner Object?
 ---@param x number
 ---@param y number
 ---@param radius number
----@param mode Collider.Mode
-function CircleCollider:init(parent, x, y, radius, mode)
-    super.init(self, parent, x, y, mode)
+---@param mode Collider.Mode?
+function CircleCollider:init(owner, x, y, radius, mode)
+    super.init(self, owner, mode)
 
+    self.x = x or 0
+    self.y = y or 0
     self.radius = radius
 end
 
-function CircleCollider:collidesWith(other)
-    other = self:getOtherCollider(other)
-    if not self:collidableCheck(other) then return false end
-    if not self:insideCheck(other) then return false end
-
-    if other.inside then
-        return other:collidesWith(self)
-    elseif self.inside then
-        if other:includes(Hitbox) then
-            local aabb, shape = other:getShapeFor(self)
-            if aabb then
-                return self:applyInvert(other, CollisionUtil.circleRectInside(self.x, self.y, self.radius, unpack(shape)))
-            else
-                return self:applyInvert(other, CollisionUtil.circlePolygonInside(self.x, self.y, self.radius, shape))
-            end
-        elseif other:includes(LineCollider) then
-            return self:applyInvert(other, CollisionUtil.circleLineInside(self.x, self.y, self.radius, other:getShapeFor(self)))
-        elseif other:includes(CircleCollider) then
-            return self:applyInvert(other, CollisionUtil.circleCircleInside(self.x, self.y, self.radius, other:getShapeFor(self)))
-        elseif other:includes(PointCollider) then
-            return self:applyInvert(other, CollisionUtil.circlePointInside(self.x, self.y, self.radius, other:getShapeFor(self)))
-        elseif other:includes(PolygonCollider) then
-            return self:applyInvert(other, CollisionUtil.circlePolygonInside(self.x, self.y, self.radius, other:getShapeFor(self)))
-        elseif other:includes(ColliderGroup) then
-            return other:collidesWith(self)
-        end
-    else
-        if other:includes(Hitbox) then
-            return other:collidesWith(self)
-        elseif other:includes(LineCollider) then
-            return self:applyInvert(other, CollisionUtil.circleLine(self.x, self.y, self.radius, other:getShapeFor(self)))
-        elseif other:includes(CircleCollider) then
-            return self:applyInvert(other, CollisionUtil.circleCircle(self.x, self.y, self.radius, other:getShapeFor(self)))
-        elseif other:includes(PointCollider) then
-            return self:applyInvert(other, CollisionUtil.circlePoint(self.x, self.y, self.radius, other:getShapeFor(self)))
-        elseif other:includes(PolygonCollider) then
-            return self:applyInvert(other, CollisionUtil.circlePolygon(self.x, self.y, self.radius, other:getShapeFor(self)))
-        elseif other:includes(ColliderGroup) then
-            return other:collidesWith(self)
-        end
-    end
-
-    return super.collidesWith(self, other)
+function CircleCollider:getColliderType()
+    return CollisionRegistry.CIRCLE
 end
 
-function CircleCollider:getShapeFor(other)
+--- Gets the circle's center and radius.
+---@return number x # The X coordinate of the circle's center.
+---@return number y # The Y coordinate of the circle's center.
+---@return number radius # The radius of the circle.
+function CircleCollider:getCircle()
+    return self.x, self.y, self.radius
+end
+
+--- Sets the circle's center and radius.
+---@param x number # The X coordinate of the circle's center.
+---@param y number # The Y coordinate of the circle's center.
+---@param radius number # The radius of the circle.
+function CircleCollider:setCircle(x, y, radius)
+    self.x = x
+    self.y = y
+    self.radius = radius
+end
+
+--- Gets the circle's center and radius relative to another collider.
+---@param other Collider # The other collider to get the circle's position relative to.
+---@return number x # The X coordinate of the circle's center relative to the other collider.
+---@return number y # The Y coordinate of the circle's center relative to the other collider.
+---@return number radius # The radius of the circle relative to the other collider.
+function CircleCollider:getCircleFor(other)
     local tf1, tf2 = other:getTransformsWith(self)
 
     local cx, cy = other:getLocalPoint(tf1, tf2, self.x, self.y)
@@ -67,12 +55,32 @@ function CircleCollider:getShapeFor(other)
     return cx, cy, MathUtils.dist(cx, cy, crx, cry)
 end
 
+--- Gets the axis-aligned bounding box of the circle.
+---@return number x # The X coordinate of the bounding box.
+---@return number y # The Y coordinate of the bounding box.
+---@return number width # The width of the bounding box.
+---@return number height # The height of the bounding box.
+function CircleCollider:getBounds()
+    return self.x - self.radius, self.y - self.radius, self.radius * 2, self.radius * 2
+end
+
+--- Draws the circle outlined with the given color.
+---@param r number? # The red component of the color.
+---@param g number? # The green component of the color.
+---@param b number? # The blue component of the color.
+---@param a number? # The alpha component of the color.
 function CircleCollider:draw(r, g, b, a)
     Draw.setColor(r, g, b, a)
     love.graphics.setLineWidth(1)
     love.graphics.circle("line", self.x, self.y, self.radius)
     Draw.setColor(1, 1, 1, 1)
 end
+
+--- Draws the circle filled with the given color.
+---@param r number? # The red component of the color.
+---@param g number? # The green component of the color.
+---@param b number? # The blue component of the color.
+---@param a number? # The alpha component of the color.
 function CircleCollider:drawFill(r, g, b, a)
     Draw.setColor(r, g, b, a)
     love.graphics.circle("fill", self.x, self.y, self.radius)

--- a/src/engine/colliders/collider.lua
+++ b/src/engine/colliders/collider.lua
@@ -34,6 +34,15 @@ function Collider:getColliderType()
     error("\"getColliderType\" not implemented for " .. TableUtils.dump(self))
 end
 
+--- Gets the axis-aligned bounding box of the collider.
+---@return number x # The X coordinate of the bounding box.
+---@return number y # The Y coordinate of the bounding box.
+---@return number width # The width of the bounding box.
+---@return number height # The height of the bounding box.
+function Collider:getBounds()
+    error("\"getBounds\" not implemented for " .. TableUtils.dump(self))
+end
+
 --- Gets the object which owns this collider.
 ---@return Object? parent # The owner of this collider, or `nil` if it has none.
 function Collider:getOwner()
@@ -128,6 +137,41 @@ function Collider:getLocalPoint(tf1, tf2, x, y)
     end
 
     return x, y
+end
+
+--- Gets the axis-aligned bounding box of the collider, transformed from one coordinate space to another.
+---@param source_tf love.Transform? # The transform of this collider relative to the common parent.
+---@param target_tf love.Transform? # The destination transform relative to the common parent.
+---@return number x # The X coordinate of the bounding box relative to the second transform.
+---@return number y # The Y coordinate of the bounding box relative to the second transform.
+---@return number width # The width of the bounding box relative to the second transform.
+---@return number height # The height of the bounding box relative to the second transform.
+function Collider:getRelativeBounds(source_tf, target_tf)
+    local bounds_x, bounds_y, bounds_w, bounds_h = self:getBounds()
+
+    local ul_x, ul_y = self:getLocalPoint(source_tf, target_tf, bounds_x, bounds_y)
+    local ur_x, ur_y = self:getLocalPoint(source_tf, target_tf, bounds_x + bounds_w, bounds_y)
+    local dr_x, dr_y = self:getLocalPoint(source_tf, target_tf, bounds_x + bounds_w, bounds_y + bounds_h)
+    local dl_x, dl_y = self:getLocalPoint(source_tf, target_tf, bounds_x, bounds_y + bounds_h)
+
+    local min_x = math.min(ul_x, ur_x, dr_x, dl_x)
+    local min_y = math.min(ul_y, ur_y, dr_y, dl_y)
+    local max_x = math.max(ul_x, ur_x, dr_x, dl_x)
+    local max_y = math.max(ul_y, ur_y, dr_y, dl_y)
+
+    return min_x, min_y, max_x - min_x, max_y - min_y
+end
+
+--- Gets the axis-aligned bounding box of the collider relative to another collider.
+---@param other Collider # The other collider to get the bounding box relative to.
+---@return number x # The X coordinate of the bounding box relative to the other collider.
+---@return number y # The Y coordinate of the bounding box relative to the other collider.
+---@return number width # The width of the bounding box relative to the other collider.
+---@return number height # The height of the bounding box relative to the other collider.
+function Collider:getBoundsFor(other)
+    local tf1, tf2 = other:getTransformsWith(self)
+
+    return self:getRelativeBounds(tf1, tf2)
 end
 
 --- Checks collision between this collider and another collider.

--- a/src/engine/colliders/collider.lua
+++ b/src/engine/colliders/collider.lua
@@ -1,88 +1,123 @@
+--- The base class for all colliders used for Kristal's collision detection system.
+---
+--- New colliders must be registered to the [`CollisionRegistry`](lua://CollisionRegistry) and override
+--- [`Collider:getColliderType`](lua://Collider.getColliderType) to return the registered type of the collider.
 ---@class Collider : Class
----@overload fun(...) : Collider
+---@field protected owner Object? # The owner of this collider.
+---@field protected collidable boolean # Whether this collider can be collided with.
+---@field protected invert boolean # Whether this collider is inverted.
+---@field protected inner boolean # Whether this collider only checks collisions fully inside its bounds.
+---@overload fun(owner: Object?, mode: Collider.Mode?) : Collider
 local Collider = Class()
 
 ---@class Collider.Mode
 ---@field invert boolean?
----@field inside boolean?
+---@field inner boolean?
 
----@param parent Object
----@param x number?
----@param y number?
----@param mode Collider.Mode
-function Collider:init(parent, x, y, mode)
-    self.parent = parent
-
-    self.x = x or 0
-    self.y = y or 0
+---@param owner Object?
+---@param mode Collider.Mode?
+function Collider:init(owner, mode)
+    self.owner = owner
 
     mode = mode or {}
     self.invert = mode.invert or false
-    self.inside = mode.inside or false
+    self.inner = mode.inner or mode.inside or false ---@diagnostic disable-line: undefined-field
 
     self.collidable = true
 end
 
-function Collider:collidableCheck(other)
-    return self.collidable and other and other.collidable and (not self.parent or self.parent.collidable) and (not other.parent or other.parent.collidable)
-end
-function Collider:insideCheck(other)
-    return not (self.inside and other.inside)
-end
-
-function Collider:applyInvert(other, val)
-    if self.invert ~= other.invert then
-        return not val
-    else
-        return val
-    end
+--- Gets the type of this collider as registered to the [`CollisionRegistry`](lua://CollisionRegistry) for collision checking.
+---
+--- This **must** be overriden by subclasses of `Collider`, and will otherwise error if attempted to check collisions with.
+---@return string collider_type # The type of this collider as registered to the [`CollisionRegistry`](lua://CollisionRegistry).
+function Collider:getColliderType()
+    error("\"getColliderType\" not implemented for " .. TableUtils.dump(self))
 end
 
-function Collider:getOtherCollider(other)
-    if isClass(other) then
-        if other:includes(Collider) then
-            return other
-        elseif other:includes(Object) and other.collidable and other.collider then
-            return other.collider
-        end
-    end
+--- Gets the object which owns this collider.
+---@return Object? parent # The owner of this collider, or `nil` if it has none.
+function Collider:getOwner()
+    return self.owner
 end
 
+--- Sets the object which owns this collider.
+---@param object Object? # The new owner of this collider, or `nil` for none.
+function Collider:setOwner(object)
+    self.owner = object
+end
+
+--- Gets whether this collider can be collided with.
+---
+--- By default, this is only `true` if the owner is also collidable.
+---@return boolean collidable # Whether this collider can be collided with.
+function Collider:isCollidable()
+    local owner = self:getOwner()
+
+    return self.collidable and (not owner or owner:isCollidable())
+end
+
+--- Sets whether this collider can be collided with.
+---@param collidable boolean # Whether this collider can be collided with.
+function Collider:setCollidable(collidable)
+    self.collidable = collidable
+end
+
+--- Gets whether this collider is inverted.
+---@return boolean inverted # Whether this collider is inverted.
+function Collider:isInverted()
+    return self.invert
+end
+
+--- Sets whether this collider is inverted.
+---@param inverted boolean # Whether this collider should be inverted.
+function Collider:setInverted(inverted)
+    self.invert = inverted
+end
+
+--- Gets whether this collider only checks collisions fully inside its bounds.
+---@return boolean inner # Whether this collider only checks collisions fully inside its bounds.
+function Collider:isInner()
+    return self.inner
+end
+
+--- Sets whether this collider only checks collisions fully inside its bounds.
+---@param inner boolean # Whether this collider should only check collisions fully inside its bounds.
+function Collider:setInner(inner)
+    self.inner = inner
+end
+
+--- Gets the full transformation of this collider, or `nil` if it has no owner.
+--- @return love.Transform? transform # The full transformation of this collider, or `nil` if it has no owner.
 function Collider:getTransform()
-    if self.parent then
-        return self.parent:getFullTransform()
+    if self:getOwner() ~= nil then
+        return self:getOwner():getFullTransform()
     else
         return nil
     end
 end
 
+--- Gets the transformations of this collider and another collider, relative to a common parent (or the stage if they have none).
+---
+--- This is useful for collision detection, allowing you to transform the points of one collider into the coordinate space of another
+--- via [`Collider:getLocalPoint`](lua://Collider.getLocalPoint).
+---@param other Collider # The other collider to get the transformations with.
+---@return love.Transform? tf1 # The transformation of this collider relative to the common parent.
+---@return love.Transform? tf2 # The transformation of the other collider relative to the common parent.
 function Collider:getTransformsWith(other)
-    if self.parent and other.parent and self.parent.parent == other.parent.parent then
-        return self.parent:getTransform(), other.parent:getTransform()
+    if self:getOwner() ~= nil and other:getOwner() ~= nil and self:getOwner().parent == other:getOwner().parent then
+        return self.owner:getTransform(), other.owner:getTransform()
     else
         return self:getTransform(), other:getTransform()
     end
 end
 
-function Collider:getPointFor(other, x, y)
-    if self.parent and other.parent then
-        return other.parent:getRelativePos(other.x + x, other.y + y, self.parent)
-    elseif self.parent then
-        return self.parent:getFullTransform():inverseTransformPoint(other.x + x, other.y + y)
-    elseif other.parent then
-        return other.parent:getFullTransform():transformPoint(other.x + x, other.y + y)
-    else
-        return other.x + x, other.y + y
-    end
-end
-
---- Gets a single point relative to a target transformation.
----@param tf1 love.Transform? # The transformation of the source collider relative to the common parent.
----@param tf2 love.Transform? # The transformation of the target collider relative to the common parent.
+--- Gets a point transformed from the coordinate space of the second collider to the first collider.
+---@param tf1 love.Transform? # The transformation of the first collider relative to the common parent.
+---@param tf2 love.Transform? # The transformation of the second collider relative to the common parent.
 ---@param x number # The X coordinate of the point to be transformed.
 ---@param y number # The Y coordinate of the point to be transformed.
----@return number local_x # The transformed X coordinate.
----@return number local_y # The transformed Y coordinate.
+---@return number local_x # The X coordinate of the point from the second collider, relative to the first collider.
+---@return number local_y # The Y coordinate of the point from the second collider, relative to the first collider.
 function Collider:getLocalPoint(tf1, tf2, x, y)
     if tf2 ~= nil then
         x, y = tf2:transformPoint(x, y)
@@ -95,10 +130,45 @@ function Collider:getLocalPoint(tf1, tf2, x, y)
     return x, y
 end
 
-function Collider:collidesWith(other)
-    return self:applyInvert(other, false)
+--- Checks collision between this collider and another collider.
+---@param collider Collider # The collider to check collision with.
+---@return boolean collides # Whether a collision occurs.
+function Collider:meetsCollider(collider)
+    return CollisionRegistry.testCollision(self, collider)
 end
 
+--- Checks collision between this collider and an object.
+---@param object Object # The object to check collision with.
+---@return boolean collides # Whether a collision occurs.
+function Collider:meetsObject(object)
+    local collider = object:getCollider()
+
+    if collider == nil then
+        return false
+    end
+
+    return self:meetsCollider(collider)
+end
+
+--- Checks collision between this collider and another collider or object.
+---@param other Collider|Object # The other collider or object to check collision with.
+---@return boolean collides # Whether a collision occurs.
+---@deprecated Use `Collider:meetsCollider` or `Collider:meetsObject` instead.
+function Collider:collidesWith(other)
+    if isClass(other) then
+        if other:includes(Collider) then
+            return self:meetsCollider(other)
+        elseif other:includes(Object) then
+            return self:meetsObject(other)
+        end
+    end
+    return false
+end
+
+--- Gets whether this collider was clicked, optionally checking a specific mouse button.
+---@param button number? # The mouse button to check. If `nil`, all buttons are checked.
+---@return boolean clicked # Whether the collider was clicked.
+---@return number button # The mouse button that was used to click the collider.
 function Collider:clicked(button)
     if not button then
         local used_button = 0
@@ -116,41 +186,52 @@ function Collider:clicked(button)
         return false, 0
     end
     local point = PointCollider(nil, x, y)
-    return self:collidesWith(point), button
+    return self:meetsCollider(point), button
 end
 
+--- Draws this collider as an outline, transforming it relative to the specified object.
+---@param obj Object # The object relative to which the collider should be drawn.
+---@param ... any # Additional arguments to pass to the drawing function.
 function Collider:drawFor(obj, ...)
-    if obj == self.parent or not self.parent then
+    if obj == self.owner or not self.owner then
         self:draw(...)
     else
         love.graphics.push()
         love.graphics.origin()
-        love.graphics.applyTransform(self.parent:getFullTransform())
+        love.graphics.applyTransform(self.owner:getFullTransform())
         self:draw(...)
         love.graphics.pop()
     end
 end
+
+--- Draws this collider as a filled shape, transforming it relative to the specified object.
+---@param obj Object # The object relative to which the collider should be drawn.
+---@param ... any # Additional arguments to pass to the drawing function.
 function Collider:drawFillFor(obj, ...)
-    if obj == self.parent or not self.parent then
+    if obj == self.owner or not self.owner then
         self:drawFill(...)
     else
         love.graphics.push()
         love.graphics.origin()
-        love.graphics.applyTransform(self.parent:getFullTransform())
+        love.graphics.applyTransform(self.owner:getFullTransform())
         self:drawFill(...)
         love.graphics.pop()
     end
 end
 
+--- Draws this collider as an outline.
+---@param ... any # Additional arguments to pass to the drawing function.
 function Collider:draw(...) end
 
+--- Draws this collider as a filled shape.
+---@param ... any # Additional arguments to pass to the drawing function.
 function Collider:drawFill(...) end
 
 function Collider:canDeepCopy()
     return true
 end
 function Collider:canDeepCopyKey(key)
-    return key ~= "parent"
+    return key ~= "owner"
 end
 
 return Collider

--- a/src/engine/colliders/collidergroup.lua
+++ b/src/engine/colliders/collidergroup.lua
@@ -1,56 +1,90 @@
+--- A collider group that contains multiple colliders and manages them as a single collider.
 ---@class ColliderGroup : Collider
----@overload fun(...) : ColliderGroup
+---@field protected colliders Collider[] # The list of colliders contained in the group.
+---@overload fun(owner: Object?, colliders: Collider[]?, mode: Collider.Mode?) : ColliderGroup
 local ColliderGroup, super = Class(Collider)
 
----@param parent Object
----@param colliders Collider[]
----@param mode Collider.Mode
-function ColliderGroup:init(parent, colliders, mode)
-    super.init(self, parent, 0, 0, mode)
+---@param owner Object?
+---@param colliders Collider[]?
+---@param mode Collider.Mode?
+function ColliderGroup:init(owner, colliders, mode)
+    super.init(self, owner, mode)
 
-    self.colliders = colliders or {}
+    self:setColliders(colliders or {})
+end
+
+function ColliderGroup:getColliderType()
+    return CollisionRegistry.GROUP
+end
+
+function ColliderGroup:setInner(inner)
+    -- Set the inner property for all colliders inside the group
     for _, collider in ipairs(self.colliders) do
-        collider.parent = collider.parent or self.parent
+        collider:setInner(inner)
+    end
+
+    super.setInner(self, inner)
+end
+
+--- Gets a list of colliders contained in the group.
+--- 
+--- Modifying the returned table directly will not update the collider group's list. To update its colliders,
+--- use [`ColliderGroup:addCollider`](lua://ColliderGroup.addCollider) or [`ColliderGroup:setColliders`](lua://ColliderGroup.setColliders)
+--- instead.
+---@return Collider[] colliders # A list of colliders contained in the group.
+function ColliderGroup:getColliders()
+    return TableUtils.copy(self.colliders)
+end
+
+--- Gets a list of colliders contained in the group, without copying them.
+---
+--- This should only be called when performance is critical (e.g. collision checking). **Do not** modify the returned
+--- table directly.
+---@return Collider[] colliders # A list of colliders contained in the group.
+function ColliderGroup:getCollidersDirect()
+    return self.colliders
+end
+
+--- Replaces the colliders in the group with the given list of colliders, setting the owner of each collider to the group's
+--- owner if they don't have one.
+---@param colliders Collider[] # The new list of colliders.
+function ColliderGroup:setColliders(colliders)
+    self.colliders = {}
+
+    for _, collider in ipairs(colliders) do
+        self:addCollider(collider)
     end
 end
 
+--- Adds a collider to the group, setting its owner to the group's owner if it doesn't have one.
+---@param collider Collider # The collider to add.
 function ColliderGroup:addCollider(collider)
-    collider.parent = collider.parent or self.parent
     table.insert(self.colliders, collider)
-end
 
-function ColliderGroup:collidesWith(other)
-    other = self:getOtherCollider(other)
-    if not self:collidableCheck(other) then return false end
-
-    for _, collider in ipairs(self.colliders) do
-        if collider:collidesWith(other) then
-            return self:applyInvert(other, true)
-        end
-    end
-
-    return super.collidesWith(self, other)
-end
-
-function ColliderGroup:drawFor(obj, r, g, b, a)
-    for _, collider in ipairs(self.colliders) do
-        collider:drawFor(obj, r, g, b, a)
-    end
-end
-function ColliderGroup:drawFillFor(obj, r, g, b, a)
-    for _, collider in ipairs(self.colliders) do
-        collider:drawFillFor(obj, r, g, b, a)
+    if collider:getOwner() == nil then
+        collider:setOwner(self:getOwner())
     end
 end
 
-function ColliderGroup:draw(r, g, b, a)
+function ColliderGroup:drawFor(obj, ...)
     for _, collider in ipairs(self.colliders) do
-        collider:draw(r, g, b, a)
+        collider:drawFor(obj, ...)
     end
 end
-function ColliderGroup:drawFill(r, g, b, a)
+function ColliderGroup:drawFillFor(obj, ...)
     for _, collider in ipairs(self.colliders) do
-        collider:drawFill(r, g, b, a)
+        collider:drawFillFor(obj, ...)
+    end
+end
+
+function ColliderGroup:draw(...)
+    for _, collider in ipairs(self.colliders) do
+        collider:draw(...)
+    end
+end
+function ColliderGroup:drawFill(...)
+    for _, collider in ipairs(self.colliders) do
+        collider:drawFill(...)
     end
 end
 

--- a/src/engine/colliders/collidergroup.lua
+++ b/src/engine/colliders/collidergroup.lua
@@ -17,6 +17,39 @@ function ColliderGroup:getColliderType()
     return CollisionRegistry.GROUP
 end
 
+function ColliderGroup:getBounds()
+    if #self.colliders == 0 then
+        return 0, 0, 0, 0
+    end
+
+    local min_x, min_y, max_x, max_y = math.huge, math.huge, -math.huge, -math.huge
+
+    for _, collider in ipairs(self.colliders) do
+        local x, y, width, height = collider:getBounds()
+
+        if collider:getOwner() == self:getOwner() then
+            min_x = math.min(min_x, x)
+            min_y = math.min(min_y, y)
+            max_x = math.max(max_x, x + width)
+            max_y = math.max(max_y, y + height)
+        else
+            local tf1, tf2 = self:getTransformsWith(collider)
+
+            local rel_ul_x, rel_ul_y = self:getLocalPoint(tf1, tf2, x, y)
+            local rel_ur_x, rel_ur_y = self:getLocalPoint(tf1, tf2, x + width, y)
+            local rel_dr_x, rel_dr_y = self:getLocalPoint(tf1, tf2, x + width, y + height)
+            local rel_dl_x, rel_dl_y = self:getLocalPoint(tf1, tf2, x, y + height)
+
+            min_x = math.min(min_x, rel_ul_x, rel_ur_x, rel_dr_x, rel_dl_x)
+            min_y = math.min(min_y, rel_ul_y, rel_ur_y, rel_dr_y, rel_dl_y)
+            max_x = math.max(max_x, rel_ul_x, rel_ur_x, rel_dr_x, rel_dl_x)
+            max_y = math.max(max_y, rel_ul_y, rel_ur_y, rel_dr_y, rel_dl_y)
+        end
+    end
+
+    return min_x, min_y, max_x - min_x, max_y - min_y
+end
+
 function ColliderGroup:setInner(inner)
     -- Set the inner property for all colliders inside the group
     for _, collider in ipairs(self.colliders) do

--- a/src/engine/colliders/collisionregistry.lua
+++ b/src/engine/colliders/collisionregistry.lua
@@ -1,0 +1,263 @@
+---@alias CollisionRegistry.CollisionTest fun(a: Collider, b: Collider): boolean
+
+---@class CollisionRegistry
+---@field private types string[]
+---@field private type_registered table<string, boolean>
+---@field private class_of table<string, Collider>
+---@field private collision_tests table<string, table<string, CollisionRegistry.CollisionTest>>
+---@field private inner_collision_tests table<string, table<string, CollisionRegistry.CollisionTest>>
+local CollisionRegistry = {}
+
+CollisionRegistry.RECTANGLE = "rectangle"
+CollisionRegistry.LINE = "line"
+CollisionRegistry.CIRCLE = "circle"
+CollisionRegistry.POINT = "point"
+CollisionRegistry.POLYGON = "polygon"
+CollisionRegistry.GROUP = "group"
+
+function CollisionRegistry.refresh()
+    CollisionRegistry.types = {}
+    CollisionRegistry.type_registered = {}
+    CollisionRegistry.class_of = {}
+    CollisionRegistry.collision_tests = {}
+    CollisionRegistry.inner_collision_tests = {}
+
+    CollisionRegistry.registerDefaultTypes()
+    Kristal.callEvent(KRISTAL_EVENT.registerColliderTypes)
+
+    CollisionRegistry.registerDefaultCollisions()
+    CollisionRegistry.registerDefaultInnerCollisions()
+    Kristal.callEvent(KRISTAL_EVENT.registerCollisions)
+
+    CollisionRegistry.validateCollisions()
+end
+
+function CollisionRegistry.getTypes()
+    return TableUtils.copy(CollisionRegistry.types)
+end
+
+function CollisionRegistry.registerDefaultTypes()
+    CollisionRegistry.registerType(CollisionRegistry.RECTANGLE, Hitbox)
+    CollisionRegistry.registerType(CollisionRegistry.LINE, LineCollider)
+    CollisionRegistry.registerType(CollisionRegistry.CIRCLE, CircleCollider)
+    CollisionRegistry.registerType(CollisionRegistry.POINT, PointCollider)
+    CollisionRegistry.registerType(CollisionRegistry.POLYGON, PolygonCollider)
+    CollisionRegistry.registerType(CollisionRegistry.GROUP, ColliderGroup)
+end
+
+function CollisionRegistry.registerDefaultCollisions()
+    -- Hitbox Collisions
+    CollisionRegistry.register(CollisionRegistry.RECTANGLE, CollisionRegistry.RECTANGLE, KristalCollisions.rectRect)
+    CollisionRegistry.register(CollisionRegistry.RECTANGLE, CollisionRegistry.LINE, KristalCollisions.rectLine, true)
+    CollisionRegistry.register(CollisionRegistry.RECTANGLE, CollisionRegistry.CIRCLE, KristalCollisions.rectCircle, true)
+    CollisionRegistry.register(CollisionRegistry.RECTANGLE, CollisionRegistry.POINT, KristalCollisions.rectPoint, true)
+
+    -- LineCollider Collisions
+    CollisionRegistry.register(CollisionRegistry.LINE, CollisionRegistry.LINE, KristalCollisions.lineLine)
+    CollisionRegistry.register(CollisionRegistry.LINE, CollisionRegistry.CIRCLE, KristalCollisions.lineCircle, true)
+    CollisionRegistry.register(CollisionRegistry.LINE, CollisionRegistry.POINT, KristalCollisions.linePoint, true)
+
+    -- CircleCollider Collisions
+    CollisionRegistry.register(CollisionRegistry.CIRCLE, CollisionRegistry.CIRCLE, KristalCollisions.circleCircle)
+    CollisionRegistry.register(CollisionRegistry.CIRCLE, CollisionRegistry.POINT, KristalCollisions.circlePoint, true)
+
+    -- PointCollider Collisions
+    CollisionRegistry.register(CollisionRegistry.POINT, CollisionRegistry.POINT, KristalCollisions.pointPoint)
+
+    -- PolygonCollider Collisions
+    CollisionRegistry.register(CollisionRegistry.POLYGON, CollisionRegistry.RECTANGLE, KristalCollisions.polygonRect, true)
+    CollisionRegistry.register(CollisionRegistry.POLYGON, CollisionRegistry.LINE, KristalCollisions.polygonLine, true)
+    CollisionRegistry.register(CollisionRegistry.POLYGON, CollisionRegistry.CIRCLE, KristalCollisions.polygonCircle, true)
+    CollisionRegistry.register(CollisionRegistry.POLYGON, CollisionRegistry.POINT, KristalCollisions.polygonPoint, true)
+    CollisionRegistry.register(CollisionRegistry.POLYGON, CollisionRegistry.POLYGON, KristalCollisions.polygonPolygon)
+
+    -- ColliderGroup Collisions
+    for _, type_id in ipairs(CollisionRegistry.getTypes()) do
+        CollisionRegistry.register(CollisionRegistry.GROUP, type_id, KristalCollisions.groupAny, true)
+    end
+end
+
+function CollisionRegistry.registerDefaultInnerCollisions()
+    -- Hitbox Collisions
+    CollisionRegistry.registerInner(CollisionRegistry.RECTANGLE, CollisionRegistry.RECTANGLE, KristalCollisions.rectRectInner)
+    CollisionRegistry.registerInner(CollisionRegistry.RECTANGLE, CollisionRegistry.LINE, KristalCollisions.rectLineInner)
+    CollisionRegistry.registerInner(CollisionRegistry.RECTANGLE, CollisionRegistry.CIRCLE, KristalCollisions.rectCircleInner)
+    CollisionRegistry.registerInner(CollisionRegistry.RECTANGLE, CollisionRegistry.POINT, KristalCollisions.rectPointInner)
+    CollisionRegistry.registerInner(CollisionRegistry.RECTANGLE, CollisionRegistry.POLYGON, KristalCollisions.rectPolygonInner)
+
+    -- LineCollider Collisions
+    CollisionRegistry.registerInner(CollisionRegistry.LINE, CollisionRegistry.RECTANGLE, KristalCollisions.lineRectInner)
+    CollisionRegistry.registerInner(CollisionRegistry.LINE, CollisionRegistry.LINE, KristalCollisions.lineLineInner)
+    CollisionRegistry.registerInner(CollisionRegistry.LINE, CollisionRegistry.CIRCLE, KristalCollisions.lineCircleInner)
+    CollisionRegistry.registerInner(CollisionRegistry.LINE, CollisionRegistry.POINT, KristalCollisions.linePointInner)
+    CollisionRegistry.registerInner(CollisionRegistry.LINE, CollisionRegistry.POLYGON, KristalCollisions.linePolygonInner)
+
+    -- CircleCollider Collisions
+    CollisionRegistry.registerInner(CollisionRegistry.CIRCLE, CollisionRegistry.RECTANGLE, KristalCollisions.circleRectInner)
+    CollisionRegistry.registerInner(CollisionRegistry.CIRCLE, CollisionRegistry.LINE, KristalCollisions.circleLineInner)
+    CollisionRegistry.registerInner(CollisionRegistry.CIRCLE, CollisionRegistry.CIRCLE, KristalCollisions.circleCircleInner)
+    CollisionRegistry.registerInner(CollisionRegistry.CIRCLE, CollisionRegistry.POINT, KristalCollisions.circlePointInner)
+    CollisionRegistry.registerInner(CollisionRegistry.CIRCLE, CollisionRegistry.POLYGON, KristalCollisions.circlePolygonInner)
+
+    -- PointCollider Collisions
+    CollisionRegistry.registerInner(CollisionRegistry.POINT, CollisionRegistry.RECTANGLE, KristalCollisions.pointRectInner)
+    CollisionRegistry.registerInner(CollisionRegistry.POINT, CollisionRegistry.LINE, KristalCollisions.pointLineInner)
+    CollisionRegistry.registerInner(CollisionRegistry.POINT, CollisionRegistry.CIRCLE, KristalCollisions.pointCircleInner)
+    CollisionRegistry.registerInner(CollisionRegistry.POINT, CollisionRegistry.POINT, KristalCollisions.pointPointInner)
+    CollisionRegistry.registerInner(CollisionRegistry.POINT, CollisionRegistry.POLYGON, KristalCollisions.pointPolygonInner)
+
+    -- PolygonCollider Collisions
+    CollisionRegistry.registerInner(CollisionRegistry.POLYGON, CollisionRegistry.RECTANGLE, KristalCollisions.polygonRectInner)
+    CollisionRegistry.registerInner(CollisionRegistry.POLYGON, CollisionRegistry.LINE, KristalCollisions.polygonLineInner)
+    CollisionRegistry.registerInner(CollisionRegistry.POLYGON, CollisionRegistry.CIRCLE, KristalCollisions.polygonCircleInner)
+    CollisionRegistry.registerInner(CollisionRegistry.POLYGON, CollisionRegistry.POINT, KristalCollisions.polygonPointInner)
+    CollisionRegistry.registerInner(CollisionRegistry.POLYGON, CollisionRegistry.POLYGON, KristalCollisions.polygonPolygonInner)
+
+    -- ColliderGroup Collisions
+    for _, type_id in ipairs(CollisionRegistry.getTypes()) do
+        CollisionRegistry.registerInner(CollisionRegistry.GROUP, type_id, KristalCollisions.groupAny, true)
+    end
+end
+
+--- Validates collision matches between all registered collider types.
+---@private
+function CollisionRegistry.validateCollisions()
+    for _, type_a in ipairs(CollisionRegistry.types) do
+        for _, type_b in ipairs(CollisionRegistry.types) do
+            local test = CollisionRegistry.collision_tests[type_a][type_b]
+            if test == nil then
+                Kristal.Console:warn("Missing collision test for: " .. type_a .. " vs " .. type_b)
+            end
+
+            local inner_test = CollisionRegistry.inner_collision_tests[type_a][type_b]
+            if inner_test == nil then
+                Kristal.Console:warn("Missing inner collision test for: " .. type_a .. " vs " .. type_b)
+            end
+        end
+    end
+end
+
+--- Registers a new collider type.
+---@generic T : Collider
+---@param id string # The unique identifier for the collider type.
+---@param class T? # The class associated with the collider type.
+function CollisionRegistry.registerType(id, class)
+    if CollisionRegistry.type_registered[id] then
+        error("Already registered collider type: " .. id)
+    end
+
+    table.insert(CollisionRegistry.types, id)
+    CollisionRegistry.type_registered[id] = true
+    CollisionRegistry.class_of[id] = class
+
+    CollisionRegistry.collision_tests[id] = {}
+    CollisionRegistry.inner_collision_tests[id] = {}
+end
+
+--- Registers a collision test between two collider types.
+---@param type_a string # The first collider type.
+---@param type_b string # The second collider type.
+---@param test CollisionRegistry.CollisionTest # The collision test function.
+---@param symmetrical boolean? # Whether to register the collision test symmetrically.
+function CollisionRegistry.register(type_a, type_b, test, symmetrical)
+    if not CollisionRegistry.type_registered[type_a] then
+        error("Collider type not registered: " .. type_a)
+    end
+    if not CollisionRegistry.type_registered[type_b] then
+        error("Collider type not registered: " .. type_b)
+    end
+
+    CollisionRegistry.collision_tests[type_a][type_b] = test
+
+    if symmetrical and type_a ~= type_b then
+        CollisionRegistry.collision_tests[type_b][type_a] = function(a, b) return test(b, a) end
+    end
+end
+
+--- Registers an inner collision test between two collider types.
+---@param type_a string # The first collider type.
+---@param type_b string # The second collider type.
+---@param test CollisionRegistry.CollisionTest # The collision test function.
+---@param symmetrical boolean? # Whether to register the inner collision test symmetrically.
+function CollisionRegistry.registerInner(type_a, type_b, test, symmetrical)
+    if not CollisionRegistry.type_registered[type_a] then
+        error("Collider type not registered: " .. type_a)
+    end
+    if not CollisionRegistry.type_registered[type_b] then
+        error("Collider type not registered: " .. type_b)
+    end
+
+    CollisionRegistry.inner_collision_tests[type_a][type_b] = test
+
+    if symmetrical and type_a ~= type_b then
+        CollisionRegistry.inner_collision_tests[type_b][type_a] = function(a, b) return test(b, a) end
+    end
+end
+
+--- Checks for a collision between two colliders.
+---@param a Collider # The first collider.
+---@param b Collider # The second collider.
+---@return boolean collided # Whether the colliders are colliding.
+function CollisionRegistry.testCollision(a, b)
+    -- Return false if either collider is not collidable
+    if not a:isCollidable() or not b:isCollidable() then
+        return false
+    end
+
+    -- Redirect to inner collision test if either collider is marked as "inner"
+    if a:isInner() then
+        if b:isInner() then
+            -- Colliders cannot be inside of eachother
+            return false
+        end
+
+        return CollisionRegistry.testInnerCollision(a, b)
+    elseif b:isInner() then
+        return CollisionRegistry.testInnerCollision(b, a)
+    end
+
+    local type_a = a:getColliderType()
+    local type_b = b:getColliderType()
+
+    local test = CollisionRegistry.collision_tests[type_a][type_b]
+
+    if test == nil then
+        -- Collision test not registered between these two collider types
+        -- The registry validation warns about this earlier, so we'll just return false
+        return false
+    end
+
+    local result = test(a, b)
+
+    if a:isInverted() ~= b:isInverted() then
+        return not result
+    else
+        return result
+    end
+end
+
+--- Checks if the second collider is inside the first collider. Not intended to be called directly.
+---@protected
+---@param a Collider # The first collider.
+---@param b Collider # The second collider.
+---@return boolean inside # Whether the second collider is inside the first collider.
+function CollisionRegistry.testInnerCollision(a, b)
+    local type_a = a:getColliderType()
+    local type_b = b:getColliderType()
+
+    local test = CollisionRegistry.inner_collision_tests[type_a][type_b]
+
+    if test == nil then
+        error("No inner collision test registered between \"" .. type_a .. "\" and \"" .. type_b .. "\"")
+    end
+
+    local result = test(a, b)
+
+    if a:isInverted() ~= b:isInverted() then
+        return not result
+    else
+        return result
+    end
+end
+
+return CollisionRegistry

--- a/src/engine/colliders/hitbox.lua
+++ b/src/engine/colliders/hitbox.lua
@@ -26,12 +26,7 @@ function Hitbox:getColliderType()
     return CollisionRegistry.RECTANGLE
 end
 
---- Gets the axis-aligned bounding box of the hitbox.
----@return number x # The X coordinate of the bounding box.
----@return number y # The Y coordinate of the bounding box.
----@return number width # The width of the bounding box.
----@return number height # The height of the bounding box.
-function Hitbox:getRect()
+function Hitbox:getBounds()
     return self.x, self.y, self.width, self.height
 end
 
@@ -40,7 +35,7 @@ end
 ---@param y number # The Y coordinate of the bounding box.
 ---@param width number # The width of the bounding box.
 ---@param height number # The height of the bounding box.
-function Hitbox:setRect(x, y, width, height)
+function Hitbox:setBounds(x, y, width, height)
     self.x = x
     self.y = y
     self.width = width
@@ -54,7 +49,7 @@ end
 function Hitbox:getRectOrPolyFor(other)
     local tf1, tf2 = other:getTransformsWith(self)
 
-    local x, y, width, height = self:getRect()
+    local x, y, width, height = self:getBounds()
 
     local ul_x, ul_y = other:getLocalPoint(tf1, tf2, x, y)
     local ur_x, ur_y = other:getLocalPoint(tf1, tf2, x + width, y)

--- a/src/engine/colliders/hitbox.lua
+++ b/src/engine/colliders/hitbox.lua
@@ -1,77 +1,65 @@
+--- A rectangular hitbox used for collision detection.
 ---@class Hitbox : Collider
----@overload fun(...) : Hitbox
+---@field x number # The X coordinate of the hitbox.
+---@field y number # The Y coordinate of the hitbox.
+---@field width number # The width of the hitbox.
+---@field height number # The height of the hitbox.
+---@overload fun(owner: Object?, x: number?, y: number?, width: number?, height: number?, mode: Collider.Mode?) : Hitbox
 local Hitbox, super = Class(Collider)
 
+---@param owner Object?
+---@param x number?
+---@param y number?
 ---@param width number?
 ---@param height number?
-function Hitbox:init(parent, x, y, width, height, mode)
-    super.init(self, parent, x, y, mode)
+---@param mode Collider.Mode?
+function Hitbox:init(owner, x, y, width, height, mode)
+    super.init(self, owner, mode)
 
+    self.x = x or 0
+    self.y = y or 0
     self.width = width or 0
     self.height = height or 0
 end
 
-function Hitbox:collidesWith(other)
-    other = self:getOtherCollider(other)
-    if not self:collidableCheck(other) then return false end
-    if not self:insideCheck(other) then return false end
+function Hitbox:getColliderType()
+    return CollisionRegistry.RECTANGLE
+end
 
-    if other.inside then
-        return other:collidesWith(self)
-    elseif self.inside then
-        if other:includes(Hitbox) then
-            local aabb, shape = other:getShapeFor(self)
-            if aabb then
-                return self:applyInvert(other, CollisionUtil.rectRectInside(self.x,self.y,self.width,self.height, unpack(shape)))
-            else
-                return self:applyInvert(other, CollisionUtil.rectPolygonInside(self.x,self.y,self.width,self.height, shape))
-            end
-        elseif other:includes(LineCollider) then
-            return self:applyInvert(other, CollisionUtil.rectLineInside(self.x,self.y,self.width,self.height, other:getShapeFor(self)))
-        elseif other:includes(CircleCollider) then
-            return self:applyInvert(other, CollisionUtil.rectCircleInside(self.x,self.y,self.width,self.height, other:getShapeFor(self)))
-        elseif other:includes(PointCollider) then
-            return self:applyInvert(other, CollisionUtil.rectPointInside(self.x,self.y,self.width,self.height, other:getShapeFor(self)))
-        elseif other:includes(PolygonCollider) then
-            return self:applyInvert(other, CollisionUtil.rectPolygonInside(self.x,self.y,self.width,self.height, other:getShapeFor(self)))
-        elseif other:includes(ColliderGroup) then
-            return other:collidesWith(self)
-        end
-    else
-        if other:includes(Hitbox) then
-            local aabb, shape = other:getShapeFor(self)
-            if aabb then
-                return self:applyInvert(other, CollisionUtil.rectRect(self.x,self.y,self.width,self.height, unpack(shape)))
-            else
-                return self:applyInvert(other, CollisionUtil.rectPolygon(self.x,self.y,self.width,self.height, shape))
-            end
-        elseif other:includes(LineCollider) then
-            return self:applyInvert(other, CollisionUtil.rectLine(self.x,self.y,self.width,self.height, other:getShapeFor(self)))
-        elseif other:includes(CircleCollider) then
-            return self:applyInvert(other, CollisionUtil.rectCircle(self.x,self.y,self.width,self.height, other:getShapeFor(self)))
-        elseif other:includes(PointCollider) then
-            return self:applyInvert(other, CollisionUtil.rectPoint(self.x,self.y,self.width,self.height, other:getShapeFor(self)))
-        elseif other:includes(PolygonCollider) then
-            return self:applyInvert(other, CollisionUtil.rectPolygon(self.x,self.y,self.width,self.height, other:getShapeFor(self)))
-        elseif other:includes(ColliderGroup) then
-            return other:collidesWith(self)
-        end
-    end
+--- Gets the axis-aligned bounding box of the hitbox.
+---@return number x # The X coordinate of the bounding box.
+---@return number y # The Y coordinate of the bounding box.
+---@return number width # The width of the bounding box.
+---@return number height # The height of the bounding box.
+function Hitbox:getRect()
+    return self.x, self.y, self.width, self.height
+end
 
-    return super.collidesWith(self, other)
+--- Sets the axis-aligned bounding box of the hitbox.
+---@param x number # The X coordinate of the bounding box.
+---@param y number # The Y coordinate of the bounding box.
+---@param width number # The width of the bounding box.
+---@param height number # The height of the bounding box.
+function Hitbox:setRect(x, y, width, height)
+    self.x = x
+    self.y = y
+    self.width = width
+    self.height = height
 end
 
 --- Gets this collider's shape as a rectangle or polygon (depending on transformation) for the given other collider.
 ---@param other Collider # The other collider to get the shape for.
 ---@return boolean aabb # `true` if the shape is a rectangle, `false` if it is a polygon.
----@return [number, number, number, number]|number[][] shape # The shape of the collider as a list of points or vertices.
-function Hitbox:getShapeFor(other)
+---@return [number, number, number, number]|number[][] shape # The shape of the collider as a rectangle or polygon.
+function Hitbox:getRectOrPolyFor(other)
     local tf1, tf2 = other:getTransformsWith(self)
 
-    local ul_x, ul_y = other:getLocalPoint(tf1, tf2, self.x, self.y)
-    local ur_x, ur_y = other:getLocalPoint(tf1, tf2, self.x + self.width, self.y)
-    local dr_x, dr_y = other:getLocalPoint(tf1, tf2, self.x + self.width, self.y + self.height)
-    local dl_x, dl_y = other:getLocalPoint(tf1, tf2, self.x, self.y + self.height)
+    local x, y, width, height = self:getRect()
+
+    local ul_x, ul_y = other:getLocalPoint(tf1, tf2, x, y)
+    local ur_x, ur_y = other:getLocalPoint(tf1, tf2, x + width, y)
+    local dr_x, dr_y = other:getLocalPoint(tf1, tf2, x + width, y + height)
+    local dl_x, dl_y = other:getLocalPoint(tf1, tf2, x, y + height)
 
     if ul_y == ur_y and ul_x == dl_x then
         local min_x, min_y = math.min(ul_x, dr_x), math.min(ul_y, dr_y)
@@ -88,15 +76,25 @@ function Hitbox:getShapeFor(other)
     }
 end
 
-function Hitbox:draw(r,g,b,a)
-    Draw.setColor(r,g,b,a)
+--- Draws the hitbox outlined with the given color.
+---@param r number? # The red component of the color.
+---@param g number? # The green component of the color.
+---@param b number? # The blue component of the color.
+---@param a number? # The alpha component of the color.
+function Hitbox:draw(r, g, b, a)
+    Draw.setColor(r, g, b, a)
     love.graphics.setLineWidth(1)
     love.graphics.rectangle("line", self.x, self.y, MathUtils.absClamp(self.width, 1, math.huge), MathUtils.absClamp(self.height, 1, math.huge))
     Draw.setColor(1, 1, 1, 1)
 end
 
-function Hitbox:drawFill(r,g,b,a)
-    Draw.setColor(r,g,b,a)
+--- Draws the hitbox filled with the given color.
+---@param r number? # The red component of the color.
+---@param g number? # The green component of the color.
+---@param b number? # The blue component of the color.
+---@param a number? # The alpha component of the color.
+function Hitbox:drawFill(r, g, b, a)
+    Draw.setColor(r, g, b, a)
     love.graphics.rectangle("fill", self.x, self.y, MathUtils.absClamp(self.width, 1, math.huge), MathUtils.absClamp(self.height, 1, math.huge))
     Draw.setColor(1, 1, 1, 1)
 end

--- a/src/engine/colliders/kristalcollisions.lua
+++ b/src/engine/colliders/kristalcollisions.lua
@@ -1,0 +1,812 @@
+---@class KristalCollisions
+local KristalCollisions = {}
+
+--#region Hitbox Collisions
+
+--#region [Base] Hitbox / Hitbox
+
+---@param a Hitbox
+---@param b Hitbox
+---@return boolean
+function KristalCollisions.rectRect(a, b)
+    local b_aabb, b_shape = b:getRectOrPolyFor(a)
+
+    if b_aabb then
+        return CollisionUtil.rectRect(
+            a.x, a.y, a.width, a.height,
+            b_shape[1], b_shape[2], b_shape[3], b_shape[4]
+        )
+    else
+        -- Perform a preliminary bounds check
+        local b_x, b_y, b_width, b_height = Utils.getPolygonBounds(b_shape)
+
+        local bounds_check = CollisionUtil.rectRect(
+            a.x, a.y, a.width, a.height,
+            b_x, b_y, b_width, b_height
+        )
+
+        if not bounds_check then
+            return false
+        end
+
+        return CollisionUtil.rectPolygon(
+            a.x, a.y, a.width, a.height,
+            b_shape
+        )
+    end
+end
+
+---@param a Hitbox
+---@param b Hitbox
+---@return boolean
+function KristalCollisions.rectRectInner(a, b)
+    local b_aabb, b_shape = b:getRectOrPolyFor(a)
+
+    if b_aabb then
+        return CollisionUtil.rectRectInside(
+            a.x, a.y, a.width, a.height,
+            b_shape[1], b_shape[2], b_shape[3], b_shape[4]
+        )
+    else
+        -- Calculation is simple, skip the usual bounds check
+        return CollisionUtil.rectPolygonInside(
+            a.x, a.y, a.width, a.height,
+            b_shape
+        )
+    end
+end
+
+--#endregion
+--#region [Base] Hitbox / LineCollider
+
+---@param rect Hitbox
+---@param line LineCollider
+---@return boolean
+function KristalCollisions.rectLine(rect, line)
+    local line_x1, line_y1, line_x2, line_y2 = line:getLineFor(rect)
+
+    -- Perform a preliminary bounds check
+    local line_bounds_x, line_bounds_y, line_bounds_w, line_bounds_h = Utils.getLineBounds(line_x1, line_y1, line_x2, line_y2)
+
+    local bounds_check = CollisionUtil.rectRect(
+        rect.x, rect.y, rect.width, rect.height,
+        line_bounds_x, line_bounds_y, line_bounds_w, line_bounds_h
+    )
+
+    if not bounds_check then
+        return false
+    end
+
+    return CollisionUtil.rectLine(
+        rect.x, rect.y, rect.width, rect.height,
+        line_x1, line_y1, line_x2, line_y2
+    )
+end
+
+---@param rect Hitbox
+---@param line LineCollider
+---@return boolean
+function KristalCollisions.rectLineInner(rect, line)
+    local line_x1, line_y1, line_x2, line_y2 = line:getLineFor(rect)
+
+    -- Calculation is simple, skip the usual bounds check
+    return CollisionUtil.rectLineInside(
+        rect.x, rect.y, rect.width, rect.height,
+        line_x1, line_y1, line_x2, line_y2
+    )
+end
+
+--#endregion
+--#region [Base] Hitbox / CircleCollider
+
+---@param rect Hitbox
+---@param circle CircleCollider
+---@return boolean
+function KristalCollisions.rectCircle(rect, circle)
+    local circle_x, circle_y, circle_radius = circle:getCircleFor(rect)
+
+    -- Perform a preliminary bounds check
+    local circle_bounds_x, circle_bounds_y, circle_bounds_w, circle_bounds_h = Utils.getCircleBounds(circle_x, circle_y, circle_radius)
+
+    local bounds_check = CollisionUtil.rectRect(
+        rect.x, rect.y, rect.width, rect.height,
+        circle_bounds_x, circle_bounds_y, circle_bounds_w, circle_bounds_h
+    )
+
+    if not bounds_check then
+        return false
+    end
+
+    return CollisionUtil.rectCircle(
+        rect.x, rect.y, rect.width, rect.height,
+        circle_x, circle_y, circle_radius
+    )
+end
+
+---@param rect Hitbox
+---@param circle CircleCollider
+---@return boolean
+function KristalCollisions.rectCircleInner(rect, circle)
+    local circle_x, circle_y, circle_radius = circle:getCircleFor(rect)
+
+    -- Calculation is simple, skip the usual bounds check
+    return CollisionUtil.rectCircleInside(
+        rect.x, rect.y, rect.width, rect.height,
+        circle_x, circle_y, circle_radius
+    )
+end
+
+--#endregion
+--#region [Base] Hitbox / PointCollider
+
+---@param rect Hitbox
+---@param point PointCollider
+---@return boolean
+function KristalCollisions.rectPoint(rect, point)
+    local point_x, point_y = point:getPointFor(rect)
+
+    return CollisionUtil.rectPoint(
+        rect.x, rect.y, rect.width, rect.height,
+        point_x, point_y
+    )
+end
+
+---@param rect Hitbox
+---@param point PointCollider
+---@return boolean
+function KristalCollisions.rectPointInner(rect, point)
+    local point_x, point_y = point:getPointFor(rect)
+
+    return CollisionUtil.rectPointInside(
+        rect.x, rect.y, rect.width, rect.height,
+        point_x, point_y
+    )
+end
+
+--#endregion
+--#region        Hitbox / PolygonCollider
+
+---@param rect Hitbox
+---@param polygon PolygonCollider
+---@return boolean
+function KristalCollisions.rectPolygonInner(rect, polygon)
+    --- Perform a preliminary bounds check
+    local poly_bounds_x, poly_bounds_y, poly_bounds_w, poly_bounds_h = polygon:getBoundsFor(rect)
+
+    local bounds_check = CollisionUtil.rectRectInside(
+        rect.x, rect.y, rect.width, rect.height,
+        poly_bounds_x, poly_bounds_y, poly_bounds_w, poly_bounds_h
+    )
+
+    if not bounds_check then
+        return false
+    end
+
+    return CollisionUtil.rectPolygonInside(
+        rect.x, rect.y, rect.width, rect.height,
+        polygon:getPointsFor(rect)
+    )
+end
+
+--#endregion
+
+--#endregion
+--#region LineCollider Collisions
+
+--#region        LineCollider / Hitbox
+
+---@param line LineCollider
+---@param rect Hitbox
+---@return boolean
+function KristalCollisions.lineRectInner(line, rect)
+    return false -- Only a point or line can be inside a line
+end
+
+--#endregion
+--#region [Base] LineCollider / LineCollider
+
+---@param a LineCollider
+---@param b LineCollider
+---@return boolean
+function KristalCollisions.lineLine(a, b)
+    local b_x1, b_y1, b_x2, b_y2 = b:getLineFor(a)
+
+    return CollisionUtil.lineLine(
+        a.x1, a.y1, a.x2, a.y2,
+        b_x1, b_y1, b_x2, b_y2
+    )
+end
+
+---@param a LineCollider
+---@param b LineCollider
+---@return boolean
+function KristalCollisions.lineLineInner(a, b)
+    local b_x1, b_y1, b_x2, b_y2 = b:getLineFor(a)
+
+    return CollisionUtil.lineLineInside(
+        a.x1, a.y1, a.x2, a.y2,
+        b_x1, b_y1, b_x2, b_y2
+    )
+end
+
+--#endregion
+--#region [Base] LineCollider / CircleCollider
+
+---@param line LineCollider
+---@param circle CircleCollider
+---@return boolean
+function KristalCollisions.lineCircle(line, circle)
+    local circle_x, circle_y, circle_radius = circle:getCircleFor(line)
+
+    return CollisionUtil.lineCircle(
+        line.x1, line.y1, line.x2, line.y2,
+        circle_x, circle_y, circle_radius
+    )
+end
+
+---@param line LineCollider
+---@param circle CircleCollider
+---@return boolean
+function KristalCollisions.lineCircleInner(line, circle)
+    return false -- Only a point or line can be inside a line
+end
+
+--#endregion
+--#region [Base] LineCollider / PointCollider
+
+---@param line LineCollider
+---@param point PointCollider
+---@return boolean
+function KristalCollisions.linePoint(line, point)
+    local point_x, point_y = point:getPointFor(line)
+
+    return CollisionUtil.linePoint(
+        line.x1, line.y1, line.x2, line.y2,
+        point_x, point_y
+    )
+end
+
+---@param line LineCollider
+---@param point PointCollider
+---@return boolean
+function KristalCollisions.linePointInner(line, point)
+    local point_x, point_y = point:getPointFor(line)
+
+    return CollisionUtil.linePointInside(
+        line.x1, line.y1, line.x2, line.y2,
+        point_x, point_y
+    )
+end
+
+--#endregion
+--#region        LineCollider / PolygonCollider
+
+---@param line LineCollider
+---@param polygon PolygonCollider
+---@return boolean
+function KristalCollisions.linePolygonInner(line, polygon)
+    return false -- Only a point or line can be inside a line
+end
+
+--#endregion
+
+--#endregion
+--#region CircleCollider Collisions
+
+--#region        CircleCollider / Hitbox
+
+---@param circle CircleCollider
+---@param rect Hitbox
+---@return boolean
+function KristalCollisions.circleRectInner(circle, rect)
+    local rect_aabb, rect_shape = rect:getRectOrPolyFor(circle)
+
+    if rect_aabb then
+        return CollisionUtil.circleRectInside(
+            circle.x, circle.y, circle.radius,
+            rect_shape[1], rect_shape[2], rect_shape[3], rect_shape[4]
+        )
+    else
+        -- Calculation is simple, skip the usual bounds check
+        return CollisionUtil.circlePolygonInside(
+            circle.x, circle.y, circle.radius,
+            rect_shape
+        )
+    end
+end
+
+--#endregion
+--#region        CircleCollider / LineCollider
+
+---@param circle CircleCollider
+---@param line LineCollider
+---@return boolean
+function KristalCollisions.circleLineInner(circle, line)
+    local line_x1, line_y1, line_x2, line_y2 = line:getLineFor(circle)
+
+    return CollisionUtil.circleLineInside(
+        circle.x, circle.y, circle.radius,
+        line_x1, line_y1, line_x2, line_y2
+    )
+end
+
+--#endregion
+--#region [Base] CircleCollider / CircleCollider
+
+---@param a CircleCollider
+---@param b CircleCollider
+---@return boolean
+function KristalCollisions.circleCircle(a, b)
+    local b_x, b_y, b_radius = b:getCircleFor(a)
+
+    return CollisionUtil.circleCircle(
+        a.x, a.y, a.radius,
+        b_x, b_y, b_radius
+    )
+end
+
+---@param a CircleCollider
+---@param b CircleCollider
+---@return boolean
+function KristalCollisions.circleCircleInner(a, b)
+    local b_x, b_y, b_radius = b:getCircleFor(a)
+
+    return CollisionUtil.circleCircleInside(
+        a.x, a.y, a.radius,
+        b_x, b_y, b_radius
+    )
+end
+
+--#endregion
+--#region [Base] CircleCollider / PointCollider
+
+---@param circle CircleCollider
+---@param point PointCollider
+---@return boolean
+function KristalCollisions.circlePoint(circle, point)
+    local point_x, point_y = point:getPointFor(circle)
+
+    return CollisionUtil.circlePoint(
+        circle.x, circle.y, circle.radius,
+        point_x, point_y
+    )
+end
+
+---@param circle CircleCollider
+---@param point PointCollider
+---@return boolean
+function KristalCollisions.circlePointInner(circle, point)
+    local point_x, point_y = point:getPointFor(circle)
+
+    return CollisionUtil.circlePointInside(
+        circle.x, circle.y, circle.radius,
+        point_x, point_y
+    )
+end
+
+--#endregion
+--#region        CircleCollider / PolygonCollider
+
+---@param circle CircleCollider
+---@param polygon PolygonCollider
+---@return boolean
+function KristalCollisions.circlePolygonInner(circle, polygon)
+    -- Perform a preliminary bounds check
+    local circle_bounds_x, circle_bounds_y, circle_bounds_w, circle_bounds_h = circle:getBounds()
+    local poly_bounds_x, poly_bounds_y, poly_bounds_w, poly_bounds_h = polygon:getBoundsFor(circle)
+
+    local bounds_check = CollisionUtil.rectRectInside(
+        circle_bounds_x, circle_bounds_y, circle_bounds_w, circle_bounds_h,
+        poly_bounds_x, poly_bounds_y, poly_bounds_w, poly_bounds_h
+    )
+
+    if not bounds_check then
+        return false
+    end
+
+    return CollisionUtil.circlePolygonInside(
+        circle.x, circle.y, circle.radius,
+        polygon:getPointsFor(circle)
+    )
+end
+
+--#endregion
+
+--#endregion
+--#region PointCollider Collisions
+
+--#region        PointCollider / Hitbox
+
+---@param point PointCollider
+---@param rect Hitbox
+---@return boolean
+function KristalCollisions.pointRectInner(point, rect)
+    return false -- Only a point can be inside a point
+end
+
+--#endregion
+--#region        PointCollider / LineCollider
+
+---@param point PointCollider
+---@param line LineCollider
+---@return boolean
+function KristalCollisions.pointLineInner(point, line)
+    return false -- Only a point can be inside a point
+end
+
+
+--#endregion
+--#region        PointCollider / CircleCollider
+
+---@param point PointCollider
+---@param circle CircleCollider
+---@return boolean
+function KristalCollisions.pointCircleInner(point, circle)
+    return false -- Only a point can be inside a point
+end
+
+--#endregion
+--#region [Base] PointCollider / PointCollider
+
+---@param a PointCollider
+---@param b PointCollider
+---@return boolean
+function KristalCollisions.pointPoint(a, b)
+    local b_x, b_y = b:getPointFor(a)
+
+    return CollisionUtil.pointPoint(
+        a.x, a.y,
+        b_x, b_y
+    )
+end
+
+---@param a PointCollider
+---@param b PointCollider
+---@return boolean
+function KristalCollisions.pointPointInner(a, b)
+    local b_x, b_y = b:getPointFor(a)
+
+    return CollisionUtil.pointPointInside(
+        a.x, a.y,
+        b_x, b_y
+    )
+end
+
+--#endregion
+--#region        PointCollider / PolygonCollider
+
+---@param point PointCollider
+---@param polygon PolygonCollider
+---@return boolean
+function KristalCollisions.pointPolygonInner(point, polygon)
+    return false -- Only a point can be inside a point
+end
+
+--#endregion
+
+--#endregion
+--#region PolygonCollider Collisions
+
+--#region [Base] PolygonCollider / Hitbox
+
+---@param polygon PolygonCollider
+---@param rect Hitbox
+---@return boolean
+function KristalCollisions.polygonRect(polygon, rect)
+    local rect_aabb, rect_shape = rect:getRectOrPolyFor(polygon)
+
+    local poly_bounds_x, poly_bounds_y, poly_bounds_w, poly_bounds_h = polygon:getBounds()
+
+    if rect_aabb then
+        local rect_x, rect_y, rect_w, rect_h = rect_shape[1], rect_shape[2], rect_shape[3], rect_shape[4]
+
+        -- Perform a preliminary bounds check
+        local bounds_check = CollisionUtil.rectRect(
+            poly_bounds_x, poly_bounds_y, poly_bounds_w, poly_bounds_h,
+            rect_x, rect_y, rect_w, rect_h
+        )
+
+        if not bounds_check then
+            return false
+        end
+
+        return CollisionUtil.polygonRect(
+            polygon:getPointsDirect(),
+            rect_x, rect_y, rect_w, rect_h
+        )
+    else
+        local rect_bounds_x, rect_bounds_y, rect_bounds_w, rect_bounds_h = Utils.getPolygonBounds(rect_shape)
+
+        -- Perform a preliminary bounds check
+        local bounds_check = CollisionUtil.rectRect(
+            poly_bounds_x, poly_bounds_y, poly_bounds_w, poly_bounds_h,
+            rect_bounds_x, rect_bounds_y, rect_bounds_w, rect_bounds_h
+        )
+
+        if not bounds_check then
+            return false
+        end
+
+        return CollisionUtil.polygonPolygon(
+            polygon:getPointsDirect(),
+            rect_shape
+        )
+    end
+end
+
+---@param polygon PolygonCollider
+---@param rect Hitbox
+---@return boolean
+function KristalCollisions.polygonRectInner(polygon, rect)
+    local rect_aabb, rect_shape = rect:getRectOrPolyFor(polygon)
+
+    local poly_bounds_x, poly_bounds_y, poly_bounds_w, poly_bounds_h = polygon:getBounds()
+
+    if rect_aabb then
+        local rect_x, rect_y, rect_w, rect_h = rect_shape[1], rect_shape[2], rect_shape[3], rect_shape[4]
+
+        -- Perform a preliminary bounds check
+        local bounds_check = CollisionUtil.rectRectInside(
+            poly_bounds_x, poly_bounds_y, poly_bounds_w, poly_bounds_h,
+            rect_x, rect_y, rect_w, rect_h
+        )
+
+        if not bounds_check then
+            return false
+        end
+
+        return CollisionUtil.polygonRectInside(
+            polygon:getPointsDirect(),
+            rect_x, rect_y, rect_w, rect_h
+        )
+    else
+        local rect_bounds_x, rect_bounds_y, rect_bounds_w, rect_bounds_h = Utils.getPolygonBounds(rect_shape)
+
+        -- Perform a preliminary bounds check
+        local bounds_check = CollisionUtil.rectRectInside(
+            poly_bounds_x, poly_bounds_y, poly_bounds_w, poly_bounds_h,
+            rect_bounds_x, rect_bounds_y, rect_bounds_w, rect_bounds_h
+        )
+
+        if not bounds_check then
+            return false
+        end
+
+        return CollisionUtil.polygonPolygonInside(
+            polygon:getPointsDirect(),
+            rect_shape
+        )
+    end
+end
+
+--#endregion
+--#region [Base] PolygonCollider / LineCollider
+
+---@param polygon PolygonCollider
+---@param line LineCollider
+---@return boolean
+function KristalCollisions.polygonLine(polygon, line)
+    local line_x1, line_y1, line_x2, line_y2 = line:getLineFor(polygon)
+
+    local poly_bounds_x, poly_bounds_y, poly_bounds_w, poly_bounds_h = polygon:getBounds()
+    local line_bounds_x, line_bounds_y, line_bounds_w, line_bounds_h = Utils.getLineBounds(line_x1, line_y1, line_x2, line_y2)
+
+    -- Perform a preliminary bounds check
+    local bounds_check = CollisionUtil.rectRect(
+        poly_bounds_x, poly_bounds_y, poly_bounds_w, poly_bounds_h,
+        line_bounds_x, line_bounds_y, line_bounds_w, line_bounds_h
+    )
+
+    if not bounds_check then
+        return false
+    end
+
+    return CollisionUtil.polygonLine(
+        polygon:getPointsDirect(),
+        line_x1, line_y1, line_x2, line_y2
+    )
+end
+
+---@param polygon PolygonCollider
+---@param line LineCollider
+---@return boolean
+function KristalCollisions.polygonLineInner(polygon, line)
+    local line_x1, line_y1, line_x2, line_y2 = line:getLineFor(polygon)
+
+    local poly_bounds_x, poly_bounds_y, poly_bounds_w, poly_bounds_h = polygon:getBounds()
+
+    -- Perform a preliminary bounds check
+    -- Rect/Line inner collision is very cheap
+    local bounds_check = CollisionUtil.rectLineInside(
+        poly_bounds_x, poly_bounds_y, poly_bounds_w, poly_bounds_h,
+        line_x1, line_y1, line_x2, line_y2
+    )
+
+    if not bounds_check then
+        return false
+    end
+
+    return CollisionUtil.polygonLineInside(
+        polygon:getPointsDirect(),
+        line_x1, line_y1, line_x2, line_y2
+    )
+end
+
+--#endregion
+--#region [Base] PolygonCollider / CircleCollider
+
+---@param polygon PolygonCollider
+---@param circle CircleCollider
+---@return boolean
+function KristalCollisions.polygonCircle(polygon, circle)
+    local circle_x, circle_y, circle_r = circle:getCircleFor(polygon)
+
+    local poly_bounds_x, poly_bounds_y, poly_bounds_w, poly_bounds_h = polygon:getBounds()
+    local circle_bounds_x, circle_bounds_y, circle_bounds_w, circle_bounds_h = Utils.getCircleBounds(circle_x, circle_y, circle_r)
+
+    -- Perform a preliminary bounds check
+    local bounds_check = CollisionUtil.rectRect(
+        poly_bounds_x, poly_bounds_y, poly_bounds_w, poly_bounds_h,
+        circle_bounds_x, circle_bounds_y, circle_bounds_w, circle_bounds_h
+    )
+
+    if not bounds_check then
+        return false
+    end
+
+    return CollisionUtil.polygonCircle(
+        polygon:getPointsDirect(),
+        circle_x, circle_y, circle_r
+    )
+end
+
+---@param polygon PolygonCollider
+---@param circle CircleCollider
+---@return boolean
+function KristalCollisions.polygonCircleInner(polygon, circle)
+    local circle_x, circle_y, circle_r = circle:getCircleFor(polygon)
+
+    local poly_bounds_x, poly_bounds_y, poly_bounds_w, poly_bounds_h = polygon:getBounds()
+
+    -- Perform a preliminary bounds check
+    -- Rect/Circle inner collision is very cheap
+    local bounds_check = CollisionUtil.rectCircleInside(
+        poly_bounds_x, poly_bounds_y, poly_bounds_w, poly_bounds_h,
+        circle_x, circle_y, circle_r
+    )
+
+    if not bounds_check then
+        return false
+    end
+
+    return CollisionUtil.polygonCircleInside(
+        polygon:getPointsDirect(),
+        circle_x, circle_y, circle_r
+    )
+end
+
+--#endregion
+--#region [Base] PolygonCollider / PointCollider
+
+---@param polygon PolygonCollider
+---@param point PointCollider
+---@return boolean
+function KristalCollisions.polygonPoint(polygon, point)
+    local point_x, point_y = point:getPointFor(polygon)
+
+    local poly_bounds_x, poly_bounds_y, poly_bounds_w, poly_bounds_h = polygon:getBounds()
+
+    -- Perform a preliminary bounds check
+    local bounds_check = CollisionUtil.rectPoint(
+        poly_bounds_x, poly_bounds_y, poly_bounds_w, poly_bounds_h,
+        point_x, point_y
+    )
+
+    if not bounds_check then
+        return false
+    end
+
+    return CollisionUtil.polygonPoint(
+        polygon:getPointsDirect(),
+        point_x, point_y
+    )
+end
+
+---@param polygon PolygonCollider
+---@param point PointCollider
+---@return boolean
+function KristalCollisions.polygonPointInner(polygon, point)
+    local point_x, point_y = point:getPointFor(polygon)
+
+    local poly_bounds_x, poly_bounds_y, poly_bounds_w, poly_bounds_h = polygon:getBounds()
+
+    -- Perform a preliminary bounds check
+    local bounds_check = CollisionUtil.rectPointInside(
+        poly_bounds_x, poly_bounds_y, poly_bounds_w, poly_bounds_h,
+        point_x, point_y
+    )
+
+    if not bounds_check then
+        return false
+    end
+
+    return CollisionUtil.polygonPointInside(
+        polygon:getPointsDirect(),
+        point_x, point_y
+    )
+end
+
+--#endregion
+--#region [Base] PolygonCollider / PolygonCollider
+
+---@param a PolygonCollider
+---@param b PolygonCollider
+---@return boolean
+function KristalCollisions.polygonPolygon(a, b)
+    local a_bounds_x, a_bounds_y, a_bounds_w, a_bounds_h = a:getBounds()
+    local b_bounds_x, b_bounds_y, b_bounds_w, b_bounds_h = b:getBoundsFor(a)
+
+    -- Perform a preliminary bounds check
+    local bounds_check = CollisionUtil.rectRect(
+        a_bounds_x, a_bounds_y, a_bounds_w, a_bounds_h,
+        b_bounds_x, b_bounds_y, b_bounds_w, b_bounds_h
+    )
+
+    if not bounds_check then
+        return false
+    end
+
+    return CollisionUtil.polygonPolygon(
+        a:getPointsDirect(),
+        b:getPointsFor(a)
+    )
+end
+
+---@param a PolygonCollider
+---@param b PolygonCollider
+---@return boolean
+function KristalCollisions.polygonPolygonInner(a, b)
+    local a_bounds_x, a_bounds_y, a_bounds_w, a_bounds_h = a:getBounds()
+    local b_bounds_x, b_bounds_y, b_bounds_w, b_bounds_h = b:getBoundsFor(a)
+
+    -- Perform a preliminary bounds check
+    local bounds_check = CollisionUtil.rectRectInside(
+        a_bounds_x, a_bounds_y, a_bounds_w, a_bounds_h,
+        b_bounds_x, b_bounds_y, b_bounds_w, b_bounds_h
+    )
+
+    if not bounds_check then
+        return false
+    end
+
+    return CollisionUtil.polygonPolygonInside(
+        a:getPointsDirect(),
+        b:getPointsFor(a)
+    )
+end
+
+--#endregion
+
+--#endregion
+--#region ColliderGroup Collisions
+
+--#region [Base] ColliderGroup / any
+
+---@param group ColliderGroup
+---@param collider Collider
+---@return boolean
+function KristalCollisions.groupAny(group, collider)
+    for _, child_collider in ipairs(group:getCollidersDirect()) do
+        if child_collider:meetsCollider(collider) then
+            return true
+        end
+    end
+
+    return false
+end
+
+--#endregion
+
+--#endregion
+
+return KristalCollisions

--- a/src/engine/colliders/linecollider.lua
+++ b/src/engine/colliders/linecollider.lua
@@ -1,84 +1,88 @@
+--- A line segment collider used for collision detection.
 ---@class LineCollider : Collider
----@overload fun(...) : LineCollider
+---@field x1 number # The X coordinate of the first point of the line segment.
+---@field y1 number # The Y coordinate of the first point of the line segment.
+---@field x2 number # The X coordinate of the second point of the line segment.
+---@field y2 number # The Y coordinate of the second point of the line segment.
+---@overload fun(owner: Object?, x1: number, y1: number, x2: number, y2: number, mode: Collider.Mode?) : LineCollider
 local LineCollider, super = Class(Collider)
 
----@param parent Object
+---@param owner Object?
 ---@param x1 number
 ---@param y1 number
 ---@param x2 number
 ---@param y2 number
----@param mode Collider.Mode
-function LineCollider:init(parent, x1, y1, x2, y2, mode)
-    super.init(self, parent, x1, y1, mode)
+---@param mode Collider.Mode?
+function LineCollider:init(owner, x1, y1, x2, y2, mode)
+    super.init(self, owner, mode)
 
+    self.x1 = x1
+    self.y1 = y1
     self.x2 = x2
     self.y2 = y2
 end
 
-function LineCollider:collidesWith(other, symmetrical)
-    other = self:getOtherCollider(other)
-    if not self:collidableCheck(other) then return false end
-    if not self:insideCheck(other) then return false end
-
-    if other.inside then
-        return other:collidesWith(self)
-    elseif self.inside then
-        if other:includes(Hitbox) then
-            local aabb, shape = other:getShapeFor(self)
-            if aabb then
-                return self:applyInvert(other, CollisionUtil.lineRectInside(self.x, self.y, self.x2, self.y2, unpack(shape)))
-            else
-                return self:applyInvert(other, CollisionUtil.linePolygonInside(self.x, self.y, self.x2, self.y2, shape))
-            end
-        elseif other:includes(LineCollider) then
-            return self:applyInvert(other, CollisionUtil.lineLineInside(self.x, self.y, self.x2, self.y2, other:getShapeFor(self)))
-        elseif other:includes(CircleCollider) then
-            return self:applyInvert(other, CollisionUtil.lineCircleInside(self.x, self.y, self.x2, self.y2, other:getShapeFor(self)))
-        elseif other:includes(PointCollider) then
-            return self:applyInvert(other, CollisionUtil.linePointInside(self.x, self.y, self.x2, self.y2, other:getShapeFor(self)))
-        elseif other:includes(PolygonCollider) then
-            return self:applyInvert(other, CollisionUtil.linePolygonInside(self.x, self.y, self.x2, self.y2, other:getShapeFor(self)))
-        elseif other:includes(ColliderGroup) then
-            return other:collidesWith(self)
-        end
-    else
-        if other:includes(Hitbox) then
-            return other:collidesWith(self)
-        elseif other:includes(LineCollider) then
-            return self:applyInvert(other, CollisionUtil.lineLine(self.x, self.y, self.x2, self.y2, other:getShapeFor(self)))
-        elseif other:includes(CircleCollider) then
-            return self:applyInvert(other, CollisionUtil.lineCircle(self.x, self.y, self.x2, self.y2, other:getShapeFor(self)))
-        elseif other:includes(PointCollider) then
-            return self:applyInvert(other, CollisionUtil.linePoint(self.x, self.y, self.x2, self.y2, other:getShapeFor(self)))
-        elseif other:includes(PolygonCollider) then
-            return self:applyInvert(other, CollisionUtil.linePolygon(self.x, self.y, self.x2, self.y2, other:getShapeFor(self)))
-        elseif other:includes(ColliderGroup) then
-            return other:collidesWith(self)
-        end
-    end
-
-    return super.collidesWith(self, other)
+function LineCollider:getColliderType()
+    return CollisionRegistry.LINE
 end
 
-function LineCollider:getShapeFor(other)
+--- Gets the coordinates of the line segment.
+---@return number x1 # The X coordinate of the first point of the line segment.
+---@return number y1 # The Y coordinate of the first point of the line segment.
+---@return number x2 # The X coordinate of the second point of the line segment.
+---@return number y2 # The Y coordinate of the second point of the line segment.
+function LineCollider:getLine()
+    return self.x1, self.y1, self.x2, self.y2
+end
+
+--- Sets the coordinates of the line segment.
+---@param x1 number # The X coordinate of the first point of the line segment.
+---@param y1 number # The Y coordinate of the first point of the line segment.
+---@param x2 number # The X coordinate of the second point of the line segment.
+---@param y2 number # The Y coordinate of the second point of the line segment.
+function LineCollider:setLine(x1, y1, x2, y2)
+    self.x1 = x1
+    self.y1 = y1
+    self.x2 = x2
+    self.y2 = y2
+end
+
+--- Gets the coordinates of the line segment relative to another collider.
+---@param other Collider # The other collider to get the line segment coordinates relative to.
+---@return number x1 # The X coordinate of the first point of the line segment relative to the other collider.
+---@return number y1 # The Y coordinate of the first point of the line segment relative to the other collider.
+---@return number x2 # The X coordinate of the second point of the line segment relative to the other collider.
+---@return number y2 # The Y coordinate of the second point of the line segment relative to the other collider.
+function LineCollider:getLineFor(other)
     local tf1, tf2 = other:getTransformsWith(self)
 
-    local x1, y1 = other:getLocalPoint(tf1, tf2, self.x, self.y)
+    local x1, y1 = other:getLocalPoint(tf1, tf2, self.x1, self.y1)
     local x2, y2 = other:getLocalPoint(tf1, tf2, self.x2, self.y2)
 
     return x1, y1, x2, y2
 end
 
+--- Draws the line with the given color.
+---@param r number? # The red component of the color.
+---@param g number? # The green component of the color.
+---@param b number? # The blue component of the color.
+---@param a number? # The alpha component of the color.
 function LineCollider:draw(r, g, b, a)
     Draw.setColor(r, g, b, a)
     love.graphics.setLineWidth(1)
-    love.graphics.line(self.x, self.y, self.x2, self.y2)
+    love.graphics.line(self.x1, self.y1, self.x2, self.y2)
     Draw.setColor(1, 1, 1, 1)
 end
+
+--- Draws the line with the given color and a thick line width.
+---@param r number? # The red component of the color.
+---@param g number? # The green component of the color.
+---@param b number? # The blue component of the color.
+---@param a number? # The alpha component of the color.
 function LineCollider:drawFill(r, g, b, a)
     Draw.setColor(r, g, b, a)
     love.graphics.setLineWidth(5)
-    love.graphics.line(self.x, self.y, self.x2, self.y2)
+    love.graphics.line(self.x1, self.y1, self.x2, self.y2)
     Draw.setColor(1, 1, 1, 1)
 end
 

--- a/src/engine/colliders/linecollider.lua
+++ b/src/engine/colliders/linecollider.lua
@@ -26,6 +26,10 @@ function LineCollider:getColliderType()
     return CollisionRegistry.LINE
 end
 
+function LineCollider:getBounds()
+    return Utils.getLineBounds(self.x1, self.y1, self.x2, self.y2)
+end
+
 --- Gets the coordinates of the line segment.
 ---@return number x1 # The X coordinate of the first point of the line segment.
 ---@return number y1 # The Y coordinate of the first point of the line segment.

--- a/src/engine/colliders/pointcollider.lua
+++ b/src/engine/colliders/pointcollider.lua
@@ -1,70 +1,69 @@
+--- A point collider used for collision detection.
 ---@class PointCollider : Collider
----@overload fun(...) : PointCollider
+---@field x number # The X coordinate of the point.
+---@field y number # The Y coordinate of the point.
+---@overload fun(owner: Object?, x: number, y: number, mode: Collider.Mode?) : PointCollider
 local PointCollider, super = Class(Collider)
 
-function PointCollider:init(parent, x, y, mode)
-    super.init(self, parent, x, y, mode)
+---@param owner Object?
+---@param x number
+---@param y number
+---@param mode Collider.Mode?
+function PointCollider:init(owner, x, y, mode)
+    super.init(self, owner, mode)
+
+    self.x = x
+    self.y = y
 end
 
-function PointCollider:collidesWith(other)
-    other = self:getOtherCollider(other)
-    if not self:collidableCheck(other) then return false end
-    if not self:insideCheck(other) then return false end
-
-    if other.inside then
-        return other:collidesWith(self)
-    elseif self.inside then
-        if other:includes(Hitbox) then
-            local aabb, shape = other:getShapeFor(self)
-            if aabb then
-                return self:applyInvert(other, CollisionUtil.pointRectInside(self.x,self.y, unpack(shape)))
-            else
-                return self:applyInvert(other, CollisionUtil.pointPolygonInside(self.x,self.y, shape))
-            end
-        elseif other:includes(LineCollider) then
-            return self:applyInvert(other, CollisionUtil.pointLineInside(self.x,self.y, other:getShapeFor(self)))
-        elseif other:includes(CircleCollider) then
-            return self:applyInvert(other, CollisionUtil.pointCircleInside(self.x,self.y, other:getShapeFor(self)))
-        elseif other:includes(PointCollider) then
-            return self:applyInvert(other, CollisionUtil.pointPointInside(self.x,self.y, other:getShapeFor(self)))
-        elseif other:includes(PolygonCollider) then
-            return self:applyInvert(other, CollisionUtil.pointPolygonInside(self.x,self.y, other:getShapeFor(self)))
-        elseif other:includes(ColliderGroup) then
-            return other:collidesWith(self)
-        end
-    else
-        if other:includes(Hitbox) then
-            return other:collidesWith(self)
-        elseif other:includes(LineCollider) then
-            return self:applyInvert(other, CollisionUtil.pointLine(self.x,self.y, other:getShapeFor(self)))
-        elseif other:includes(CircleCollider) then
-            return self:applyInvert(other, CollisionUtil.pointCircle(self.x,self.y, other:getShapeFor(self)))
-        elseif other:includes(PointCollider) then
-            return self:applyInvert(other, CollisionUtil.pointPoint(self.x,self.y, other:getShapeFor(self)))
-        elseif other:includes(PolygonCollider) then
-            return self:applyInvert(other, CollisionUtil.pointPolygon(self.x,self.y, other:getShapeFor(self)))
-        elseif other:includes(ColliderGroup) then
-            return other:collidesWith(self)
-        end
-    end
-
-    return super.collidesWith(self, other)
+function PointCollider:getColliderType()
+    return CollisionRegistry.POINT
 end
 
-function PointCollider:getShapeFor(other)
+--- Gets the coordinates of the point.
+---@return number x # The X coordinate of the point.
+---@return number y # The Y coordinate of the point.
+function PointCollider:getPoint()
+    return self.x, self.y
+end
+
+--- Sets the coordinates of the point.
+---@param x number # The X coordinate of the point.
+---@param y number # The Y coordinate of the point.
+function PointCollider:setPoint(x, y)
+    self.x = x
+    self.y = y
+end
+
+--- Gets the coordinates of the point relative to another collider.
+---@param other Collider # The other collider to get the point relative to.
+---@return number x # The X coordinate of the point relative to the other collider.
+---@return number y # The Y coordinate of the point relative to the other collider.
+function PointCollider:getPointFor(other)
     local tf1, tf2 = other:getTransformsWith(self)
 
     return other:getLocalPoint(tf1, tf2, self.x, self.y)
 end
 
-function PointCollider:draw(r,g,b,a)
-    Draw.setColor(r,g,b,a)
+--- Draws the point with the given color.
+---@param r number? # The red component of the color.
+---@param g number? # The green component of the color.
+---@param b number? # The blue component of the color.
+---@param a number? # The alpha component of the color.
+function PointCollider:draw(r, g, b, a)
+    Draw.setColor(r, g, b, a)
     love.graphics.setPointSize(3)
     love.graphics.points(self.x, self.y)
     Draw.setColor(1, 1, 1, 1)
 end
-function PointCollider:drawFill(r,g,b,a)
-    Draw.setColor(r,g,b,a)
+
+--- Draws the point with the given color and a larger size.
+---@param r number? # The red component of the color.
+---@param g number? # The green component of the color.
+---@param b number? # The blue component of the color.
+---@param a number? # The alpha component of the color.
+function PointCollider:drawFill(r, g, b, a)
+    Draw.setColor(r, g, b, a)
     love.graphics.setPointSize(5)
     love.graphics.points(self.x, self.y)
     Draw.setColor(1, 1, 1, 1)

--- a/src/engine/colliders/pointcollider.lua
+++ b/src/engine/colliders/pointcollider.lua
@@ -20,6 +20,10 @@ function PointCollider:getColliderType()
     return CollisionRegistry.POINT
 end
 
+function PointCollider:getBounds()
+    return self.x, self.y, 0, 0
+end
+
 --- Gets the coordinates of the point.
 ---@return number x # The X coordinate of the point.
 ---@return number y # The Y coordinate of the point.

--- a/src/engine/colliders/polygoncollider.lua
+++ b/src/engine/colliders/polygoncollider.lua
@@ -1,63 +1,62 @@
+--- A polygonal collider used for collision detection.
 ---@class PolygonCollider : Collider
----@field protected points number[][]
----@overload fun(...) : PolygonCollider
+---@field protected points number[][] # The points of the polygon as a list of `{x, y}` pairs.
+---@field protected bounds_x number # The X coordinate of the polygon's bounding box.
+---@field protected bounds_y number # The Y coordinate of the polygon's bounding box.
+---@field protected bounds_width number # The width of the polygon's bounding box.
+---@field protected bounds_height number # The height of the polygon's bounding box.
+---@overload fun(owner: Object?, points: number[][], mode: Collider.Mode?) : PolygonCollider
 local PolygonCollider, super = Class(Collider)
 
----@param parent Object?
+---@param owner Object?
 ---@param points number[][]
 ---@param mode Collider.Mode?
-function PolygonCollider:init(parent, points, mode)
-    super.init(self, parent, 0, 0, mode)
+function PolygonCollider:init(owner, points, mode)
+    super.init(self, owner, mode)
 
-    self.points = points
+    self:setPoints(points)
 end
 
-function PolygonCollider:collidesWith(other)
-    other = self:getOtherCollider(other)
-    if not self:collidableCheck(other) then return false end
-    if not self:insideCheck(other) then return false end
+function PolygonCollider:getColliderType()
+    return CollisionRegistry.POLYGON
+end
 
-    if other.inside then
-        return other:collidesWith(self)
-    elseif self.inside then
-        if other:includes(Hitbox) then
-            local aabb, shape = other:getShapeFor(self)
-            if aabb then
-                return self:applyInvert(other, CollisionUtil.polygonRectInside(self.points, unpack(shape)))
-            else
-                return self:applyInvert(other, CollisionUtil.polygonPolygonInside(self.points, shape))
-            end
-        elseif other:includes(LineCollider) then
-            return self:applyInvert(other, CollisionUtil.polygonLineInside(self.points, other:getShapeFor(self)))
-        elseif other:includes(CircleCollider) then
-            return self:applyInvert(other, CollisionUtil.polygonCircleInside(self.points, other:getShapeFor(self)))
-        elseif other:includes(PointCollider) then
-            return self:applyInvert(other, CollisionUtil.polygonPointInside(self.points, other:getShapeFor(self)))
-        elseif other:includes(PolygonCollider) then
-            return self:applyInvert(other, CollisionUtil.polygonPolygonInside(self.points, other:getShapeFor(self)))
-        elseif other:includes(ColliderGroup) then
-            return other:collidesWith(self)
-        end
-    else
-        if other:includes(Hitbox) then
-            return other:collidesWith(self)
-        elseif other:includes(LineCollider) then
-            return self:applyInvert(other, CollisionUtil.polygonLine(self.points, other:getShapeFor(self)))
-        elseif other:includes(CircleCollider) then
-            return self:applyInvert(other, CollisionUtil.polygonCircle(self.points, other:getShapeFor(self)))
-        elseif other:includes(PointCollider) then
-            return self:applyInvert(other, CollisionUtil.polygonPoint(self.points, other:getShapeFor(self)))
-        elseif other:includes(PolygonCollider) then
-            return self:applyInvert(other, CollisionUtil.polygonPolygon(self.points, other:getShapeFor(self)))
-        elseif other:includes(ColliderGroup) then
-            return other:collidesWith(self)
-        end
+--- Gets the points of the polygon collider as a list of `{x, y}` pairs.
+---
+--- Modifying the returned table directly will not affect the internal points of the polygon collider. To update its points,
+--- use [`PolygonCollider:setPoints`](lua://PolygonCollider.setPoints) instead.
+---@return number[][] points # The points of the polygon collider as a list of `{x, y}` pairs.
+function PolygonCollider:getPoints()
+    local points = {}
+
+    for i, point in ipairs(self.points) do
+        points[i] = {point[1], point[2]}
     end
 
-    return super.collidesWith(self, other)
+    return points
 end
 
-function PolygonCollider:getShapeFor(other)
+--- Sets the points of the polygon collider.
+---@param points number[][] # The new points of the polygon collider as a list of `{x, y}` pairs.
+function PolygonCollider:setPoints(points)
+    self.points = points
+
+    self.bounds_x, self.bounds_y, self.bounds_width, self.bounds_height = Utils.getPolygonBounds(points)
+end
+
+--- Gets the points of the polygon collider as a list of `{x, y}` pairs, without copying them.
+---
+--- This should only be called when performance is critical (e.g. collision checking). **Do not** modify the returned
+--- table directly.
+---@return number[][] points # The points of the polygon collider as a list of `{x, y}` pairs.
+function PolygonCollider:getPointsDirect()
+    return self.points
+end
+
+--- Gets the points of the polygon collider relative to another collider.
+---@param other Collider # The other collider to get the points relative to.
+---@return number[][] shape # The points of the polygon collider as a list of `{x, y}` pairs.
+function PolygonCollider:getPointsFor(other)
     local tf1, tf2 = other:getTransformsWith(self)
 
     local local_points = {}
@@ -71,8 +70,46 @@ function PolygonCollider:getShapeFor(other)
     return local_points
 end
 
-function PolygonCollider:draw(r,g,b,a)
-    Draw.setColor(r,g,b,a)
+--- Gets the axis-aligned bounding box of the polygon collider.
+---@return number x # The X coordinate of the bounding box.
+---@return number y # The Y coordinate of the bounding box.
+---@return number width # The width of the bounding box.
+---@return number height # The height of the bounding box.
+function PolygonCollider:getBounds()
+    return self.bounds_x, self.bounds_y, self.bounds_width, self.bounds_height
+end
+
+--- Gets the axis-aligned bounding box of the polygon collider relative to another collider.
+---@param other Collider # The other collider to get the bounding box relative to.
+---@return number x # The X coordinate of the bounding box relative to the other collider.
+---@return number y # The Y coordinate of the bounding box relative to the other collider.
+---@return number width # The width of the bounding box relative to the other collider.
+---@return number height # The height of the bounding box relative to the other collider.
+function PolygonCollider:getBoundsFor(other)
+    local tf1, tf2 = other:getTransformsWith(self)
+
+    local bounds_x, bounds_y, bounds_w, bounds_h = self:getBounds()
+
+    local ul_x, ul_y = other:getLocalPoint(tf1, tf2, bounds_x, bounds_y)
+    local ur_x, ur_y = other:getLocalPoint(tf1, tf2, bounds_x + bounds_w, bounds_y)
+    local dr_x, dr_y = other:getLocalPoint(tf1, tf2, bounds_x + bounds_w, bounds_y + bounds_h)
+    local dl_x, dl_y = other:getLocalPoint(tf1, tf2, bounds_x, bounds_y + bounds_h)
+
+    local min_x = math.min(ul_x, ur_x, dr_x, dl_x)
+    local min_y = math.min(ul_y, ur_y, dr_y, dl_y)
+    local max_x = math.max(ul_x, ur_x, dr_x, dl_x)
+    local max_y = math.max(ul_y, ur_y, dr_y, dl_y)
+
+    return min_x, min_y, max_x - min_x, max_y - min_y
+end
+
+--- Draws the polygon collider outlined with the given color.
+---@param r number? # The red component of the color.
+---@param g number? # The green component of the color.
+---@param b number? # The blue component of the color.
+---@param a number? # The alpha component of the color.
+function PolygonCollider:draw(r, g, b, a)
+    Draw.setColor(r, g, b, a)
     love.graphics.setLineWidth(1)
     local unpacked = {}
     for _,point in ipairs(self.points) do
@@ -84,8 +121,14 @@ function PolygonCollider:draw(r,g,b,a)
     love.graphics.line(unpack(unpacked))
     Draw.setColor(1, 1, 1, 1)
 end
-function PolygonCollider:drawFill(r,g,b,a)
-    Draw.setColor(r,g,b,a)
+
+--- Draws the polygon collider filled with the given color.
+---@param r number? # The red component of the color.
+---@param g number? # The green component of the color.
+---@param b number? # The blue component of the color.
+---@param a number? # The alpha component of the color.
+function PolygonCollider:drawFill(r, g, b, a)
+    Draw.setColor(r, g, b, a)
     local unpacked = {}
     for _,point in ipairs(self.points) do
         table.insert(unpacked, point[1])

--- a/src/engine/colliders/polygoncollider.lua
+++ b/src/engine/colliders/polygoncollider.lua
@@ -21,6 +21,10 @@ function PolygonCollider:getColliderType()
     return CollisionRegistry.POLYGON
 end
 
+function PolygonCollider:getBounds()
+    return self.bounds_x, self.bounds_y, self.bounds_width, self.bounds_height
+end
+
 --- Gets the points of the polygon collider as a list of `{x, y}` pairs.
 ---
 --- Modifying the returned table directly will not affect the internal points of the polygon collider. To update its points,
@@ -68,39 +72,6 @@ function PolygonCollider:getPointsFor(other)
     end
 
     return local_points
-end
-
---- Gets the axis-aligned bounding box of the polygon collider.
----@return number x # The X coordinate of the bounding box.
----@return number y # The Y coordinate of the bounding box.
----@return number width # The width of the bounding box.
----@return number height # The height of the bounding box.
-function PolygonCollider:getBounds()
-    return self.bounds_x, self.bounds_y, self.bounds_width, self.bounds_height
-end
-
---- Gets the axis-aligned bounding box of the polygon collider relative to another collider.
----@param other Collider # The other collider to get the bounding box relative to.
----@return number x # The X coordinate of the bounding box relative to the other collider.
----@return number y # The Y coordinate of the bounding box relative to the other collider.
----@return number width # The width of the bounding box relative to the other collider.
----@return number height # The height of the bounding box relative to the other collider.
-function PolygonCollider:getBoundsFor(other)
-    local tf1, tf2 = other:getTransformsWith(self)
-
-    local bounds_x, bounds_y, bounds_w, bounds_h = self:getBounds()
-
-    local ul_x, ul_y = other:getLocalPoint(tf1, tf2, bounds_x, bounds_y)
-    local ur_x, ur_y = other:getLocalPoint(tf1, tf2, bounds_x + bounds_w, bounds_y)
-    local dr_x, dr_y = other:getLocalPoint(tf1, tf2, bounds_x + bounds_w, bounds_y + bounds_h)
-    local dl_x, dl_y = other:getLocalPoint(tf1, tf2, bounds_x, bounds_y + bounds_h)
-
-    local min_x = math.min(ul_x, ur_x, dr_x, dl_x)
-    local min_y = math.min(ul_y, ur_y, dr_y, dl_y)
-    local max_x = math.max(ul_x, ur_x, dr_x, dl_x)
-    local max_y = math.max(ul_y, ur_y, dr_y, dl_y)
-
-    return min_x, min_y, max_x - min_x, max_y - min_y
 end
 
 --- Draws the polygon collider outlined with the given color.

--- a/src/engine/game/battle.lua
+++ b/src/engine/game/battle.lua
@@ -2065,6 +2065,7 @@ end
 ---@param collider Collider|Object
 ---@return boolean          collided
 ---@return Arena|Solid?     colliding_with
+---@deprecated Use `Battle:solidMeetsCollider` or `Battle:solidMeetsObject` instead
 function Battle:checkSolidCollision(collider)
     if NOCLIP then return false end
     Object.startCache()
@@ -2076,6 +2077,52 @@ function Battle:checkSolidCollision(collider)
     end
     for _, solid in ipairs(Game.stage:getObjects(Solid)) do
         if solid:collidesWith(collider) then
+            Object.endCache()
+            return true, solid
+        end
+    end
+    Object.endCache()
+    return false
+end
+
+--- Returns whether a Collider collides with a Solid or the arena
+---@param collider Collider
+---@return boolean          collided
+---@return Arena|Solid?     colliding_with
+function Battle:solidMeetsCollider(collider)
+    if NOCLIP then return false end
+    Object.startCache()
+    if self.arena then
+        if self.arena:meetsCollider(collider) then
+            Object.endCache()
+            return true, self.arena
+        end
+    end
+    for _, solid in ipairs(Game.stage:getObjects(Solid)) do
+        if solid:meetsCollider(collider) then
+            Object.endCache()
+            return true, solid
+        end
+    end
+    Object.endCache()
+    return false
+end
+
+--- Returns whether an Object collides with a Solid or the arena
+---@param object Object
+---@return boolean          collided
+---@return Arena|Solid?     colliding_with
+function Battle:solidMeetsObject(object)
+    if NOCLIP then return false end
+    Object.startCache()
+    if self.arena then
+        if self.arena:meetsObject(object) then
+            Object.endCache()
+            return true, self.arena
+        end
+    end
+    for _, solid in ipairs(Game.stage:getObjects(Solid)) do
+        if solid:meetsObject(object) then
             Object.endCache()
             return true, solid
         end

--- a/src/engine/game/battle/arena.lua
+++ b/src/engine/game/battle/arena.lua
@@ -94,10 +94,11 @@ function Arena:setShape(shape)
 
     self.area_collider = PolygonCollider(self, TableUtils.copy(shape, true))
 
-    self.collider.colliders = {}
+    local colliders = {}
     for _, v in ipairs(Utils.getPolygonEdges(self.shape)) do
-        table.insert(self.collider.colliders, LineCollider(self, v[1][1], v[1][2], v[2][1], v[2][2]))
+        table.insert(colliders, LineCollider(self, v[1][1], v[1][2], v[2][1], v[2][2]))
     end
+    self.collider:setColliders(colliders)
 end
 
 ---@param r number
@@ -244,13 +245,13 @@ function Arena:update()
     if soul and Game.battle.soul.collidable then
         Object.startCache()
         local angle_diff = self.clockwise and -(math.pi / 2) or (math.pi / 2)
-        for _, line in ipairs(self.collider.colliders) do
+        for _, line in ipairs(self.collider:getCollidersDirect()) do
             ---@cast line LineCollider
 
             local angle
-            while soul:collidesWith(line) do
+            while soul:meetsCollider(line) do
                 if not angle then
-                    local x1, y1 = self:getRelativePos(line.x, line.y, Game.battle)
+                    local x1, y1 = self:getRelativePos(line.x1, line.y1, Game.battle)
                     local x2, y2 = self:getRelativePos(line.x2, line.y2, Game.battle)
                     angle = Utils.angle(x1, y1, x2, y2)
                 end

--- a/src/engine/game/battle/solid.lua
+++ b/src/engine/game/battle/solid.lua
@@ -85,7 +85,7 @@ function Solid:doMoveAmount(amount, x_mult, y_mult)
         Object.uncache(self)
 
         for _, soul in ipairs(Game.stage:getObjects(Soul)) do
-            if self:collidesWith(soul) then
+            if self:meetsObject(soul) then
                 soul_collided = true
 
                 self.collidable = false

--- a/src/engine/game/battle/soul.lua
+++ b/src/engine/game/battle/soul.lua
@@ -303,13 +303,13 @@ function Soul:moveXExact(amount, move_y)
         if not self.noclip then
             Object.uncache(self)
             Object.startCache()
-            local collided, target = Game.battle:checkSolidCollision(self)
+            local collided, target = Game.battle:solidMeetsObject(self)
             if self.slope_correction then
                 if collided and not (move_y > 0) then
                     for j = 1, 2 do
                         Object.uncache(self)
                         self.y = self.y - 1
-                        collided, target = Game.battle:checkSolidCollision(self)
+                        collided, target = Game.battle:solidMeetsObject(self)
                         if not collided then break end
                     end
                 end
@@ -318,7 +318,7 @@ function Soul:moveXExact(amount, move_y)
                     for j = 1, 2 do
                         Object.uncache(self)
                         self.y = self.y + 1
-                        collided, target = Game.battle:checkSolidCollision(self)
+                        collided, target = Game.battle:solidMeetsObject(self)
                         if not collided then break end
                     end
                 end
@@ -358,13 +358,13 @@ function Soul:moveYExact(amount, move_x)
         if not self.noclip then
             Object.uncache(self)
             Object.startCache()
-            local collided, target = Game.battle:checkSolidCollision(self)
+            local collided, target = Game.battle:solidMeetsObject(self)
             if self.slope_correction then
                 if collided and not (move_x > 0) then
                     for j = 1, 2 do
                         Object.uncache(self)
                         self.x = self.x - 1
-                        collided, target = Game.battle:checkSolidCollision(self)
+                        collided, target = Game.battle:solidMeetsObject(self)
                         if not collided then break end
                     end
                 end
@@ -373,7 +373,7 @@ function Soul:moveYExact(amount, move_x)
                     for j = 1, 2 do
                         Object.uncache(self)
                         self.x = self.x + 1
-                        collided, target = Game.battle:checkSolidCollision(self)
+                        collided, target = Game.battle:solidMeetsObject(self)
                         if not collided then break end
                     end
                 end
@@ -496,13 +496,13 @@ function Soul:update()
     local collided_bullets = {}
     Object.startCache()
     for _, bullet in ipairs(Game.stage:getObjects(Bullet)) do
-        if bullet:collidesWith(self.collider) then
+        if bullet:meetsCollider(self:getCollider()) then
             -- Store collided bullets to a table before calling onCollide
             -- to avoid issues with cacheing inside onCollide
             table.insert(collided_bullets, bullet)
         end
         if not Game:hasInvulnerability() then
-            if bullet:canGraze() and bullet:collidesWith(self.graze_collider) then
+            if bullet:canGraze() and bullet:meetsCollider(self.graze_collider) then
                 local old_graze = bullet.grazed
                 if bullet.grazed then
                     Game:giveTension(bullet:getGrazeTension() * DT * self.graze_tp_factor)

--- a/src/engine/game/world.lua
+++ b/src/engine/game/world.lua
@@ -525,9 +525,9 @@ end
 function World:checkCollision(collider, enemy_check)
     Object.startCache()
     for _,other in ipairs(self:getCollision(enemy_check)) do
-        if collider:collidesWith(other) and collider ~= other then
+        if collider:meetsCollider(other) and collider ~= other then
             Object.endCache()
-            return true, other.parent
+            return true, other:getOwner()
         end
     end
     Object.endCache()
@@ -543,8 +543,8 @@ function World:checkCollisions(collider, enemy_check)
     local collided_with = {}
     Object.startCache()
     for _, other in ipairs(self:getCollision(enemy_check)) do
-        if collider:collidesWith(other) and collider ~= other then
-            table.insert(collided_with, other.parent)
+        if collider:meetsCollider(other) and collider ~= other then
+            table.insert(collided_with, other:getOwner())
         end
     end
     Object.endCache()
@@ -1350,7 +1350,7 @@ function World:update()
         for _, obj in ipairs(self.children) do
             if not obj.solid and (obj.onCollide or obj.onEnter or obj.onExit) then
                 for _, char in ipairs(self.stage:getObjects(Character)) do
-                    if obj:collidesWith(char) and self:shouldCharacterCollide(char) then
+                    if obj:meetsObject(char) and self:shouldCharacterCollide(char) then
                         if not obj:includes(OverworldSoul) then
                             table.insert(collided, { obj, char })
                         end

--- a/src/engine/game/world/character.lua
+++ b/src/engine/game/world/character.lua
@@ -216,12 +216,12 @@ function Character:doMoveAmount(type, amount, other_amount)
 
         if (not self.noclip) and (not NOCLIP) then
             Object.startCache()
-            local collided, target = self.world:checkCollision(self.collider, self.enemy_collision)
+            local collided, target = self.world:checkCollision(self:getCollider(), self.enemy_collision)
             if collided and not (other_amount > 0) then
                 for j = 1, 2 do
                     Object.uncache(self)
                     self[other] = self[other] - j
-                    collided, target = self.world:checkCollision(self.collider, self.enemy_collision)
+                    collided, target = self.world:checkCollision(self:getCollider(), self.enemy_collision)
                     if not collided then break end
                 end
             end
@@ -230,7 +230,7 @@ function Character:doMoveAmount(type, amount, other_amount)
                 for j = 1, 2 do
                     Object.uncache(self)
                     self[other] = self[other] + j
-                    collided, target = self.world:checkCollision(self.collider, self.enemy_collision)
+                    collided, target = self.world:checkCollision(self:getCollider(), self.enemy_collision)
                     if not collided then break end
                 end
             end

--- a/src/engine/game/world/chaserenemy.lua
+++ b/src/engine/game/world/chaserenemy.lua
@@ -302,7 +302,7 @@ function ChaserEnemy:update()
         if self.alert_timer == 0 and self.can_chase and not self.chasing then
             if self.world.player then
                 Object.startCache()
-                local in_radius = self.world.player:collidesWith(CircleCollider(self.world, self.x, self.y, self.chase_dist))
+                local in_radius = self.world.player:meetsCollider(CircleCollider(self.world, self.x, self.y, self.chase_dist))
                 if in_radius then
                     local sight = LineCollider(self.world, self.x, self.y, self.world.player.x, self.world.player.y)
                     if not self.world:checkCollision(sight, true) and not self.world:checkCollision(self.collider, true) then

--- a/src/engine/game/world/events/climbing/climbmover.lua
+++ b/src/engine/game/world/events/climbing/climbmover.lua
@@ -200,7 +200,7 @@ function ClimbMover:update()
 
     if self.state == "WAITING_FOR_DISMOUNT" then
         -- We gotta wait for the player to dismount...
-        if not Game.world.player:collidesWith(self) then
+        if not Game.world.player:meetsObject(self) then
             self.state = "RESETTING"
             self.timer = 0
             self:setClimbable(false)

--- a/src/engine/game/world/events/climbing/fallingclimbarea.lua
+++ b/src/engine/game/world/events/climbing/fallingclimbarea.lua
@@ -76,7 +76,7 @@ function FallingClimbArea:update()
     local target = Game.world.player
 
     if self.breaks_on_leave then
-        if target ~= nil and (not target:collidesWith(self)) then
+        if target ~= nil and (not target:meetsObject(self)) then
             if self.dont_break == nil then
                 self.state = 2
                 should_destroy = true

--- a/src/engine/game/world/events/magicglass.lua
+++ b/src/engine/game/world/events/magicglass.lua
@@ -65,7 +65,7 @@ function MagicGlass:update()
     local valid_objs = {}
 
     for _, obj in ipairs(self:getGlassRevealingObjects()) do
-        if obj:collidesWith(self.collider) then
+        if obj:meetsCollider(self.collider) then
             table.insert(valid_objs, obj)
         end
     end
@@ -74,7 +74,7 @@ function MagicGlass:update()
 
     for i, collider in ipairs(self.glass_colliders) do
         for _, obj in ipairs(valid_objs) do
-            if collider:collidesWith(obj) then
+            if obj:meetsCollider(collider) then
                 table.insert(collided, obj)
             end
         end

--- a/src/engine/game/world/events/pushblock.lua
+++ b/src/engine/game/world/events/pushblock.lua
@@ -95,7 +95,7 @@ function PushBlock:checkCollision(facing)
 
     Object.startCache()
     for _, collider in ipairs(Game.world.map.block_collision) do
-        if collider:collidesWith(bound_check) then
+        if collider:meetsCollider(bound_check) then
             collided = true
             break
         end

--- a/src/engine/game/world/events/slidearea.lua
+++ b/src/engine/game/world/events/slidearea.lua
@@ -45,7 +45,7 @@ function SlideArea:update()
 
     Object.startCache()
 
-    if Game.world.player.y > self.y + self.height and not Game.world.player:collidesWith(self.collider) then
+    if Game.world.player.y > self.y + self.height and not Game.world.player:meetsCollider(self.collider) then
         self.solid = true
     else
         self.solid = false

--- a/src/engine/game/world/events/tilebutton.lua
+++ b/src/engine/game/world/events/tilebutton.lua
@@ -74,7 +74,7 @@ function TileButton:update()
         Object.startCache()
         local collided = nil
         for _,block in ipairs(Game.stage:getObjects(PushBlock)) do
-            if block.press_buttons ~= false and block:collidesWith(self) then
+            if block.press_buttons ~= false and block:meetsObject(self) then
                 collided = block
                 break
             end

--- a/src/engine/game/world/overworldsoul.lua
+++ b/src/engine/game/world/overworldsoul.lua
@@ -56,7 +56,7 @@ function OverworldSoul:update()
     if not Game.world.player or Game.world.player.state ~= "CLIMB" then
         Object.startCache()
         for _, bullet in ipairs(Game.stage:getObjects(WorldBullet)) do
-            if bullet:collidesWith(self.collider) then
+            if bullet:meetsCollider(self.collider) then
                 self:onCollide(bullet)
             end
         end

--- a/src/engine/game/world/player.lua
+++ b/src/engine/game/world/player.lua
@@ -192,7 +192,7 @@ function Player:interact()
     Object.startCache()
     local interactables = {}
     for _, obj in ipairs(self.world.children) do
-        if obj.onInteract and obj:collidesWith(col) then
+        if obj.onInteract and obj:meetsCollider(col) then
             local rx, ry = obj:getRelativePos(obj.width / 2, obj.height / 2, self.parent)
             table.insert(interactables, { obj = obj, dist = MathUtils.dist(self.x, self.y, rx, ry) })
         end
@@ -752,7 +752,7 @@ function Player:update()
 
     self.world.in_battle_area = false
     for _, area in ipairs(self.world.map.battle_areas) do
-        if area:collidesWith(self.collider) then
+        if area:meetsCollider(self.collider) then
             if not self.world.in_battle_area then
                 self.world.in_battle_area = true
             end

--- a/src/engine/game/world/playerclimbstate.lua
+++ b/src/engine/game/world/playerclimbstate.lua
@@ -219,7 +219,7 @@ function PlayerClimbState:getOverlappingObjects(object, x, y)
     Object.startCache()
     for _, obj in ipairs(Game.stage:getObjects(object)) do
         if obj.parent == Game.world then
-            if obj:collidesWith(self.player) then
+            if obj:meetsObject(self.player) then
                 table.insert(objects, obj)
             end
         end
@@ -254,7 +254,7 @@ function PlayerClimbState:isOverlappingObject(object, x, y)
     Object.startCache()
     for _, obj in ipairs(Game.stage:getObjects(object)) do
         if obj.parent == Game.world then
-            if obj:collidesWith(self.player) then
+            if obj:meetsObject(self.player) then
                 found_obj = obj
                 break
             end
@@ -290,7 +290,7 @@ function PlayerClimbState:isOverlappingClimbable(object, x, y)
     Object.startCache()
     for _, obj in ipairs(Game.stage:getObjects(object)) do
         if obj.parent == Game.world then
-            if obj:isClimbable() and obj:collidesWith(self.player) then
+            if obj:isClimbable() and obj:meetsObject(self.player) then
                 found_obj = obj
                 break
             end
@@ -593,7 +593,7 @@ function PlayerClimbState:checkClimbBullets()
     if Game.world.soul ~= nil and Game.inv_frames <= 0 and self.player:isMovementEnabled() then
         Object.startCache()
         for _, bullet in ipairs(Game.stage:getObjects(WorldBullet)) do
-            if bullet:collidesWith(self.hurtbox) then
+            if bullet:meetsCollider(self.hurtbox) then
                 if bullet:includes(ClimbEnemy) then
                     ---@cast bullet ClimbEnemy
                     if bullet:isActive() and not self.player:isClimbJumping() then
@@ -621,7 +621,7 @@ function PlayerClimbState:checkClimbCollisions()
 
         Object.startCache()
         for _, obj in ipairs(Game.world.children) do
-            if obj:collidesWith(self.player) then
+            if obj:meetsObject(self.player) then
                 if obj:includes(ClimbEnemy) then
                     ---@cast obj ClimbEnemy
                     if obj:isActive() and self.player:isClimbJumping() then
@@ -692,7 +692,7 @@ end
 function PlayerClimbState:checkClimbLandings()
     Object.startCache()
     for _, obj in ipairs(Game.world.children) do
-        if obj:includes(ClimbLanding) and self.player:collidesWith(obj) then
+        if obj:includes(ClimbLanding) and self.player:meetsObject(obj) then
             self:queueExit({ landing = true, obj = obj })
             break
         end

--- a/src/engine/game/world/playerslidebasestate.lua
+++ b/src/engine/game/world/playerslidebasestate.lua
@@ -70,7 +70,7 @@ function PlayerSlideBaseState:checkSlideEnd()
 
     Object.startCache()
     for _, obj in ipairs(Game.world.children) do
-        if obj:includes(SlideArea) and obj:collidesWith(self.player) then
+        if obj:includes(SlideArea) and obj:meetsObject(self.player) then
             is_colliding = true
             self.was_colliding = true
             break

--- a/src/engine/object.lua
+++ b/src/engine/object.lua
@@ -662,15 +662,49 @@ end
 --- Whether the object is colliding with another object or collider.
 ---@param other Object|Collider The object or collider to check collision with.
 ---@return boolean collided Whether the collision occurred or not.
+---@deprecated Use `Object:meetsCollider` or `Object:meetsObject` instead.
 function Object:collidesWith(other)
-    if other and self.collidable and self.collider then
-        if isClass(other) and other:includes(Object) then
-            return other.collidable and other.collider and self.collider:collidesWith(other.collider) or false
-        else
-            return self.collider:collidesWith(other)
+    local collider = self:getCollider()
+
+    if collider == nil then
+        return false
+    end
+
+    if isClass(other) then
+        if other:includes(Object) then
+            return collider:meetsObject(other)
+        elseif other:includes(Collider) then
+            return collider:meetsCollider(other)
         end
     end
+
     return false
+end
+
+--- Checks if the object is colliding with the specified collider.
+---@param collider Collider The collider to check collision with.
+---@return boolean collided Whether the collision occurred or not.
+function Object:meetsCollider(collider)
+    local self_collider = self:getCollider()
+
+    if self_collider == nil then
+        return false
+    end
+
+    return self_collider:meetsCollider(collider)
+end
+
+--- Checks if the object is colliding with the specified object.
+---@param object Object The object to check collision with.
+---@return boolean collided Whether the collision occurred or not.
+function Object:meetsObject(object)
+    local self_collider = self:getCollider()
+
+    if self_collider == nil then
+        return false
+    end
+
+    return self_collider:meetsObject(object)
 end
 
 --- Sets the object's `x` and `y` values to the specified position.
@@ -1040,16 +1074,34 @@ function Object:getDirection()
     return (self.physics.match_rotation and self.rotation) or self.physics.direction or 0
 end
 
+--- Returns the object's current collider.
+---@return Collider? collider The object's current collider, or `nil` if it has none.
+function Object:getCollider()
+    return self.collider
+end
+
+--- Sets the object's current collider.
+---@param collider Collider? The object's new collider, or `nil` for none.
+function Object:setCollider(collider)
+    self.collider = collider
+end
+
+--- Returns whether the object should be able to collide with other objects.
+---@return boolean collidable Whether the object should be able to collide with other objects.
+function Object:isCollidable()
+    return self.collidable
+end
+
 --- Returns the dimensions of the object's `collider` if that collider is a Hitbox.
 ---@return number? x The `x` position of the collider, relative to the object.
 ---@return number? y The `y` position of the collider, relative to the object.
 ---@return number? width The `width` of the collider, in pixels.
 ---@return number? height The `height` of the collider, in pixels.
 function Object:getHitbox()
-    local collider = self.collider
+    local collider = self:getCollider()
     if collider and collider:includes(Hitbox) then
         ---@cast collider Hitbox
-        return collider.x, collider.y, collider.width, collider.height
+        return collider:getRect()
     end
 end
 
@@ -1059,7 +1111,7 @@ end
 ---@param w number The `width` of the collider, in pixels.
 ---@param h number The `height` of the collider, in pixels.
 function Object:setHitbox(x, y, w, h)
-    self.collider = Hitbox(self, x, y, w, h)
+    self:setCollider(Hitbox(self, x, y, w, h))
 end
 
 --- *(Override)* Used by World to determine what position should be used when sorting its layer. \
@@ -1459,7 +1511,7 @@ function Object:clicked(button)
     end
     if self.collider then
         local point = PointCollider(nil, x, y)
-        return self.collider:collidesWith(point), button
+        return self.collider:meetsCollider(point), button
     else
         -- roughly same code as DebugSystem:detectObject(x, y)
         local mx, my = self:getFullTransform():inverseTransformPoint(x, y)

--- a/src/engine/vars.lua
+++ b/src/engine/vars.lua
@@ -278,6 +278,10 @@ KRISTAL_EVENT = {
     registerDebugContext = "registerDebugContext", -- new debug ContextMenu created / at: DebugSystem:onMousePressed(x, y, button, istouch, presses), DebugSystem:openObjectContext(object) / passes: ContextMenu:context, Object:selected_object / return: NONE
     registerDebugOptions = "registerDebugOptions", -- DebugSystem is ready to recieve custom debug options / passes: DebugSystem:self / returns: NONE
 
+    --collider events--
+    registerColliderTypes = "registerColliderTypes", -- called when collider types are registered / passes: NONE / returns: NONE
+    registerCollisions = "registerCollisions", -- called when collider collisions are registered / passes: NONE / returns: NONE
+
     --asset registration events-- (sorted by execution order)
     onRegisterActors = "onRegisterActors", -- actor scripts finished registering / in: Registry.initActors() / passes: NONE / returns: NONE
     onRegisterGlobals = "onRegisterGlobals", -- global scripts finished registering / in: Registry.initGlobals() / passes: NONE / returns: NONE

--- a/src/kristal.lua
+++ b/src/kristal.lua
@@ -157,6 +157,9 @@ function love.load(args)
     Registry.initialize()
     Registry.saveData()
 
+    -- register collisions
+    CollisionRegistry.refresh()
+
     -- Chapter defaults
     Kristal.ChapterConfigs = {}
     Kristal.ChapterConfigs[1] = JSON.decode(love.filesystem.read("configs/chapter1.json"))
@@ -1257,6 +1260,9 @@ function Kristal.clearModState()
     Assets.restoreData()
     Registry.restoreData()
 
+    -- Refresh the collision registry
+    CollisionRegistry.refresh()
+
     -- force garbage collection
     collectgarbage("collect")
 end
@@ -1595,6 +1601,9 @@ function Kristal.preInitMod(id)
 
     -- Initialize registry
     Registry.initialize()
+
+    -- Refresh collision registry
+    CollisionRegistry.refresh()
 
     -- Return true if no "preInit" explicitly returns true
     return use_callback

--- a/src/utils/tiledutils.lua
+++ b/src/utils/tiledutils.lua
@@ -205,10 +205,10 @@ function TiledUtils.colliderFromShape(parent, data, x, y, properties)
     properties = properties or {}
 
     -- Optional properties for collider behaviour
-    -- "outside" is the same as enabling both "inverted" and "inside"
+    -- "outside" is the same as enabling both "inverted" and "inner"
     local mode = {
         invert = properties["inverted"] or properties["outside"] or false,
-        inside = properties["inside"] or properties["outside"] or false
+        inner = properties["inner"] or properties["inside"] or properties["outside"] or false
     }
 
     local current_hitbox

--- a/src/utils/utils.lua
+++ b/src/utils/utils.lua
@@ -1044,12 +1044,53 @@ end
 ---@return number height # The height of the bounds.
 ---
 function Utils.getPolygonBounds(points)
-    local min_x, min_y, max_x, max_y
-    for _, point in ipairs(points) do
-        min_x, min_y = math.min(min_x or point[1], point[1]), math.min(min_y or point[2], point[2])
-        max_x, max_y = math.max(max_x or point[1], point[1]), math.max(max_y or point[2], point[2])
+    if #points == 0 then
+        return 0, 0, 0, 0
     end
+
+    local min_x, min_y = math.huge, math.huge
+    local max_x, max_y = -math.huge, -math.huge
+
+    for _, point in ipairs(points) do
+        local x, y = point[1], point[2]
+
+        min_x, min_y = math.min(min_x, x), math.min(min_y, y)
+        max_x, max_y = math.max(max_x, x), math.max(max_y, y)
+    end
+
     return min_x, min_y, (max_x - min_x), (max_y - min_y)
+end
+
+--- Returns the bounding box of a line segment.
+---@param x1 number # The X coordinate of the first point of the line segment.
+---@param y1 number # The Y coordinate of the first point of the line segment.
+---@param x2 number # The X coordinate of the second point of the line segment.
+---@param y2 number # The Y coordinate of the second point of the line segment.
+---@return number x # The X coordinate of the bounding box.
+---@return number y # The Y coordinate of the bounding box.
+---@return number width # The width of the bounding box.
+---@return number height # The height of the bounding box.
+function Utils.getLineBounds(x1, y1, x2, y2)
+    local min_x = math.min(x1, x2)
+    local min_y = math.min(y1, y2)
+    local max_x = math.max(x1, x2)
+    local max_y = math.max(y1, y2)
+
+    return min_x, min_y, max_x - min_x, max_y - min_y
+end
+
+--- Returns the bounding box of a circle.
+---@param x number # The X coordinate of the center of the circle.
+---@param y number # The Y coordinate of the center of the circle.
+---@param radius number # The radius of the circle.
+---@return number x # The X coordinate of the bounding box.
+---@return number y # The Y coordinate of the bounding box.
+---@return number width # The width of the bounding box.
+---@return number height # The height of the bounding box.
+function Utils.getCircleBounds(x, y, radius)
+    local diameter = radius * 2
+
+    return x - radius, y - radius, diameter, diameter
 end
 
 ---
@@ -1773,10 +1814,10 @@ function Utils.colliderFromShape(parent, data, x, y, properties)
     properties = properties or {}
 
     -- Optional properties for collider behaviour
-    -- "outside" is the same as enabling both "inverted" and "inside"
+    -- "outside" is the same as enabling both "inverted" and "inner"
     local mode = {
         invert = properties["inverted"] or properties["outside"] or false,
-        inside = properties["inside"] or properties["outside"] or false
+        inner = properties["inner"] or properties["inside"] or properties["outside"] or false
     }
 
     local current_hitbox


### PR DESCRIPTION
Opening a PR for this to have more time for testing / review.

**Changes:**
Colliders have been massively restructured and slightly optimized with bounding box checks
- `collidesWith` has been split into `meetsCollider` / `meetsObject` in most cases, and has been deprecated
- Collision detection between different collider types is now handled with a new CollisionRegistry system
  - Each unique type of Collider (e.g. `"rectangle"`, `"point"`) is now registered to the CollisionRegistry, and Colliders now have a `getColliderType` returning their collider type
  - Collision tests between collider types must now be registered as functions to the CollisionRegistry, optionally symmetrically, and separately for "inner" collisions
- Many more specific changes to Collider functions/fields to list

The Collider changes and new collision registry system is intended to be documented on the wiki soon, for now here's the most important changes for an average codebase:
- `collidesWith` --> `meetsCollider` / `meetsObject`
  - This applies to both Collider and Object, and is a context dependent replacement. `collidesWith` will still work for now although it is deprecated.
- `Battle:checkSolidCollision` --> `Battle:solidMeetsCollider` / `Battle:solidMeetsObject`
- `Collider.parent` --> `Collider:getOwner()` / `Collider:setOwner(object)`
- `Collider.collidable` --> `Collider:isCollidable()` / `Collider:setCollidable(collidable)`
  - `Collider:isCollidable()` also checks if its owner is collidable.
- `Collider.inside` --> `Collider:isInner()` / `Collider:setInner()`
  - `inside` has been renamed to `inner` in every location.
- `PolygonCollider.points` --> `PolygonCollider:getPoints()` / `PolygonCollider:setPoints(points)`
  - You can no longer modify the `points` field directly, due to bounding box optimizations.
- `LineCollider.x`, `LineCollider.y` --> `LineCollider.x1`, `LineCollider.y1`
If you made a custom collider, see the CollisionRegistry class for how to use it, and use the `registerColliderTypes` and `registerCollisions` events respectively.