### PR TITLE
use calculateDamageSimple in chapter 1

### DIFF
--- a/configs/chapter1.json
+++ b/configs/chapter1.json
@@ -19,6 +19,7 @@
     "oldRudeBuster": true,           // Old Rude Buster damage calculation and effect
     "oldPacify": true,               // Removes the animation from the Pacify spell
     "oldDualHealFormula": true,      // Old Dual Heal amount calculation
+    "oldDefenseFormula": true,       // Old defense calculation
 
     "speechBubble": "round",         // Default enemy speech bubble style
     "lightTextboxStyle": "light",    // Textbox style used in the light world (by default)

--- a/configs/chapter2.json
+++ b/configs/chapter2.json
@@ -19,6 +19,7 @@
     "oldRudeBuster": true,           // Old Rude Buster damage calculation and effect
     "oldPacify": false,              // Removes the animation from the Pacify spell
     "oldDualHealFormula": false,     // Old Dual Heal amount calculation
+    "oldDefenseFormula": false,      // Old defense calculation
 
     "speechBubble": "cyber",         // Default enemy speech bubble style
     "lightTextboxStyle": "light",    // Textbox style used in the light world (by default)

--- a/configs/chapter3.json
+++ b/configs/chapter3.json
@@ -19,6 +19,7 @@
     "oldRudeBuster": false,          // Old Rude Buster damage calculation and effect
     "oldPacify": false,              // Removes the animation from the Pacify spell
     "oldDualHealFormula": false,     // Old Dual Heal amount calculation
+    "oldDefenseFormula": false,      // Old defense calculation
 
     "speechBubble": "cyber",         // Default enemy speech bubble style
     "lightTextboxStyle": "light",    // Textbox style used in the light world (by default)

--- a/configs/chapter4.json
+++ b/configs/chapter4.json
@@ -19,6 +19,7 @@
     "oldRudeBuster": false,          // Old Rude Buster damage calculation and effect
     "oldPacify": false,              // Removes the animation from the Pacify spell
     "oldDualHealFormula": false,     // Old Dual Heal amount calculation
+    "oldDefenseFormula": false,      // Old defense calculation
 
     "speechBubble": "cyber",         // Default enemy speech bubble style
     "lightTextboxStyle": "light",    // Textbox style used in the light world (by default)

--- a/configs/chapter5.json
+++ b/configs/chapter5.json
@@ -19,6 +19,7 @@
     "oldRudeBuster": false,          // Old Rude Buster damage calculation and effect
     "oldPacify": false,              // Removes the animation from the Pacify spell
     "oldDualHealFormula": false,     // Old Dual Heal amount calculation
+    "oldDefenseFormula": false,      // Old defense calculation
 
     "speechBubble": "cyber",         // Default enemy speech bubble style
     "lightTextboxStyle": "light",    // Textbox style used in the light world (by default)

--- a/src/engine/game/battle/partybattler.lua
+++ b/src/engine/game/battle/partybattler.lua
@@ -93,8 +93,7 @@ function PartyBattler:calculateDamage(amount)
     return math.max(amount, 1)
 end
 
---- Less complex damage calculation than [`PartyBattler:calculateDamage()`](lua://PartyBattler.calculateDamage) \
---- (unused?)
+--- Less complex damage calculation than [`PartyBattler:calculateDamage()`](lua://PartyBattler.calculateDamage), used in chapter 1 
 ---@param amount number
 ---@return integer
 function PartyBattler:calculateDamageSimple(amount)
@@ -141,7 +140,11 @@ function PartyBattler:hurt(amount, exact, color, options)
     if not options["all"] then
         Assets.playSound("hurt")
         if not exact then
-            amount = self:calculateDamage(amount)
+            if Game:getConfig("oldDefenseFormula") then
+                amount = self:calculateDamageSimple(amount)
+            else
+                amount = self:calculateDamage(amount)
+            end
             if self.defending then
                 amount = math.ceil((2 * amount) / 3)
             end
@@ -157,7 +160,11 @@ function PartyBattler:hurt(amount, exact, color, options)
     else
         -- We're targeting everyone.
         if not exact then
-            amount = self:calculateDamage(amount)
+            if Game:getConfig("oldDefenseFormula") then
+                amount = self:calculateDamageSimple(amount)
+            else
+                amount = self:calculateDamage(amount)
+            end
             -- we don't have elements right now
             local element = 0
             amount = math.ceil((amount * self:getElementReduction(element)))

--- a/src/engine/game/battle/partybattler.lua
+++ b/src/engine/game/battle/partybattler.lua
@@ -97,7 +97,8 @@ end
 ---@param amount number
 ---@return integer
 function PartyBattler:calculateDamageSimple(amount)
-    return math.ceil(amount - (self.chara:getStat("defense") * 3))
+    local damage = math.ceil(amount - (self.chara:getStat("defense") * 3))
+    return math.max(damage, 1)
 end
 
 --- Gets the damage reduction multiplier for damage of a particular element

--- a/src/engine/menu/mainmenumodconfig.lua
+++ b/src/engine/menu/mainmenumodconfig.lua
@@ -218,6 +218,7 @@ function MainMenuModConfig:registerOptions()
     self:registerOption("oldRudeBuster", "Old Rude Buster", "Whether to use Chapter 1/2 Rude Buster damage calculation and effect.", "selection", { nil, true, false })
     self:registerOption("oldPacify", "Old Pacify", "Whether to remove the animation from the Pacify spell", "selection", { nil, true, false })
     self:registerOption("oldDualHealFormula", "Old Dual Heal Formula", "Whether to use Chapter 1 Dual Heal calculation or not", "selection", { nil, true, false })
+    self:registerOption("oldDefenseFormula", "Old Defense Formula", "Whether to use Chapter 1 defense calculation or not", "selection", {nil, true, false})
     self:registerOption("targetSystem", "Targeting System", "Whether battles should use the targeting system or not", "selection", { nil, true, false })
     self:registerOption("soulInvBetweenWaves", "Keep Soul Invulnerability", "Whether the soul invulnerability will carry between waves in battles", "selection", { nil, true, false })
     self:registerOption("speechBubble", "Speech Bubble Style", "The default style for enemy speech bubbles", "selection", { nil, "round", "cyber" }) -- unhardcode


### PR DESCRIPTION
Chapter 1 makes use of the simplified `damage - (defense*3)` damage formula, instead of the more complicated system found in Chapter 2 onward. ([Source](https://youtu.be/_07PUJBkeUI?t=1045)) This is now controlled by the `oldDefenseFormula` config option.
Additionally, `calculateDamageSimple` was not properly capping its output, which I have now fixed.