### PR TITLE
Add FLAC support

### DIFF
--- a/src/engine/loadthread.lua
+++ b/src/engine/loadthread.lua
@@ -123,7 +123,7 @@ local loaders = {
                 pcall(function() mod.logo_data = love.image.newImageData(full_path .. "/logo.png") end)
             end
 
-            local music_extensions = { "mp3", "ogg", "wav" }
+            local music_extensions = { "mp3", "ogg", "wav", "flac" }
             for _, ext in ipairs(music_extensions) do
                 if love.filesystem.getInfo(full_path .. "/preview." .. ext) then
                     mod.preview_music_path = full_path .. "/preview." .. ext
@@ -135,7 +135,7 @@ local loaders = {
                 for _, file in ipairs(love.filesystem.getDirectoryItems(full_path .. "/preview")) do
                     if file == "preview.lua" then
                         mod.preview_script_path = full_path .. "/preview/preview.lua"
-                    elseif file == "preview.ogg" or file == "preview.mp3" or file == "preview.wav" then
+                    elseif file == "preview.ogg" or file == "preview.mp3" or file == "preview.wav" or file == "preview.flac" then
                         mod.preview_music_path = full_path .. "/preview/" .. file
                     elseif file:sub(-4) == ".png" then
                         local img_name = file:sub(1, -4)
@@ -294,7 +294,7 @@ local loaders = {
         end
     end },
     ["sounds"] = { "assets/sounds", function(base_dir, path, full_path)
-        local id = checkExtension(path, "wav", "ogg")
+        local id = checkExtension(path, "wav", "ogg", "flac")
         if id then
             pcall(function() data.assets.sound_data[id] = love.sound.newSoundData(full_path) end)
         end
@@ -309,7 +309,7 @@ local loaders = {
     end },
     ["music"] = { "assets/music", function(base_dir, path, full_path)
         local id = checkExtension(
-            path, "mp3", "wav", "ogg",
+            path, "mp3", "wav", "ogg", "flac",
             -- TRACKER FORMATS
             "mod", "s3m", "xm", "it", "669", "amf", "ams", "dbm", "dmf", "dsm", "far",
             "mdl", "med", "mtm", "okt", "ptm", "stm", "ult", "umx", "mt2", "psm",


### PR DESCRIPTION
I just noticed that Kristal doesn't index .flac music and sound files, yet [LÖVE supports this format from version 11.3](https://love2d.org/wiki/Audio_Formats). Since Kristal targets 11.5 and I couldn't even make it run on LÖVE 11.3 or lower anyway, I think it's safe to add FLAC indexing as is, but I could implement additional version check if needed.