### PR TITLE
Mech Pencil check name fix

### DIFF
--- a/data/items/items/manual.lua
+++ b/data/items/items/manual.lua
@@ -48,7 +48,7 @@ function item:init()
 end
 
 function item:onWorldUse(target)
-    Game.world:showText("* (You tried to read the manual,\nbut it was so dense it made\nyour head spin...)")
+    Game.world:showText("* (You tried to read the manual,[wait:5]\nbut it was so dense it made\nyour head spin...)")
     return false
 end
 

--- a/data/items/light/mech_pencil.lua
+++ b/data/items/light/mech_pencil.lua
@@ -32,4 +32,8 @@ function item:init()
     self.dark_item = "mechasaber"
 end
 
+function item:onCheck()
+    Game.world:showText("* \"Mechanical Pencil\" - " .. self:getCheck())
+end
+
 return item


### PR DESCRIPTION
Check description has it as "Mechanical Pencil" instead of "Mech. Pencil".

Maybe a "check_name" field could be added like "use_name"?