### PR TITLE
Updated the enemy hurt shake and defeatrun animation to be accurate to DELTARUNE

### DIFF
--- a/src/engine/game/battle.lua
+++ b/src/engine/game/battle.lua
@@ -1332,7 +1332,9 @@ function Battle:processAction(action)
             end
         end
 
-        battler:setAnimation("battle/attack", function()
+        battler:setAnimation("battle/attack")
+
+        self.timer:after(10 / 30, function()
             action.icon = nil
 
             if action.target and action.target.done_state then

--- a/src/engine/game/battle/enemybattler.lua
+++ b/src/engine/game/battle/enemybattler.lua
@@ -874,7 +874,7 @@ function EnemyBattler:onHurt(damage, battler)
     if not self:getActiveSprite():setAnimation("hurt") then
         self:toggleOverlay(false)
     end
-    self:getActiveSprite():shake(9, 0, 0.5, 2 / 30)
+    self:getActiveSprite():shake(9, 0, 1, 2 / 30, true)
 
     if self.health <= (self.max_health * self.tired_percentage) then
         -- If `tired_percentage` is set to 0 (or less?), treat that as an indication to hide the message.
@@ -910,6 +910,7 @@ end
 ---@param damage?    number
 ---@param battler?   PartyBattler
 function EnemyBattler:onDefeatRun(damage, battler)
+    self:getActiveSprite():stopShake()
     self.hurt_timer = -1
     self.defeated = true
 

--- a/src/engine/menu/mainmenucredits.lua
+++ b/src/engine/menu/mainmenucredits.lua
@@ -69,6 +69,7 @@ function MainMenuCredits:init(menu)
                 "MaybeSamo",
                 "MCdeDaxia",
                 "MihBoss96",
+                "mpjasonreal",
                 "MrOinky"
             }
         },
@@ -94,8 +95,7 @@ function MainMenuCredits:init(menu)
                 "TheSkerch",
                 "Verozity",
                 "WIL-TZY",
-                "YeetusSnoopy",
-                "mpjasonreal"
+                "YeetusSnoopy"
             }
         }
     }

--- a/src/engine/menu/mainmenucredits.lua
+++ b/src/engine/menu/mainmenucredits.lua
@@ -94,7 +94,8 @@ function MainMenuCredits:init(menu)
                 "TheSkerch",
                 "Verozity",
                 "WIL-TZY",
-                "YeetusSnoopy"
+                "YeetusSnoopy",
+                "mpjasonreal"
             }
         }
     }

--- a/src/engine/object.lua
+++ b/src/engine/object.lua
@@ -395,6 +395,7 @@ end
 ---@field shake_friction number       The amount the object's shake will slow down, per frame at 30FPS.
 ---@field shake_delay    number       The time it takes for the object to invert its shake direction, in seconds.
 ---@field shake_timer    number       *(Used internally)* A timer used to invert the object's shake direction.
+---@field shake_ignorescale boolean  If the shake amount should ignore the object's and its parents' scales.
 
 --- Resets all of the object's `graphics` table values to their default values, \
 --- making it so it will stop transforming if it was before.
@@ -426,7 +427,9 @@ function Object:resetGraphics()
         -- Shake speed (How much time it takes to invert the shake)
         shake_delay = 2 / 30,
         -- Shake timer (used to invert the shake)
-        shake_timer = 0
+        shake_timer = 0,
+        -- If the shake amount should ignore object and parent scaling
+        shake_ignorescale = false
     }
 end
 
@@ -485,12 +488,14 @@ end
 ---@param y?        number   The amount of shake in the `y` direction. (Defaults to `0`)
 ---@param friction? number   The amount that the shake should decrease by, per frame at 30FPS. (Defaults to `1`)
 ---@param delay?    number   The time it takes for the object to invert its shake direction, in seconds. (Defaults to `1/30`)
-function Object:shake(x, y, friction, delay)
+---@param ignorescale? boolean If the shake amount should ignore the object's and its parents' scales. (Defaults to `false`)
+function Object:shake(x, y, friction, delay, ignorescale)
     self.graphics.shake_x = x or 4
     self.graphics.shake_y = y or 0
     self.graphics.shake_friction = friction or 1
     self.graphics.shake_delay = delay or (1 / 30)
     self.graphics.shake_timer = 0
+    self.graphics.shake_ignorescale = ignorescale or false
 end
 
 --- Stops the object from shaking.
@@ -1362,7 +1367,14 @@ function Object:applyTransformTo(transform, floor_x, floor_y)
     end
     if self.graphics and ((self.graphics.shake_x and self.graphics.shake_x ~= 0) or (self.graphics.shake_y and self.graphics.shake_y ~= 0)) then
         local shake_x, shake_y = math.ceil(self.graphics.shake_x), math.ceil(self.graphics.shake_y)
-        if not floor_x then
+        if self.graphics.shake_ignorescale then
+            if floor_x then
+                transform:translate(shake_x * floor_x, shake_y * floor_y)
+            else
+                local scale_x, scale_y = self:getFullScale()
+                transform:translate(scale_x ~= 0 and shake_x / scale_x or 0, scale_y ~= 0 and shake_y / scale_y or 0)
+            end
+        elseif not floor_x then
             transform:translate(shake_x, shake_y)
         else
             transform:translate(MathUtils.floorToMultiple(shake_x, floor_x), MathUtils.floorToMultiple(shake_y, floor_y))


### PR DESCRIPTION
### This fixes some inaccuracies between Kristal's enemy damage animation behavior and DELTARUNE's implementation of it

These fixes include:

- Instead of waiting for the attack animation to finish, the engine now applies damage 10 frames after the attack begins
- Hurt shake is now accurate to the real game
- The hurt shake stops when an enemy enters the defeatrun state
- Added a new ignorescale argument to Object:shake(). It defaults to false so that existing shakes retain their original behavior, but the enemy hurt shake sets this to true so it matches DELTARUNE's behavior

## Comparison

| Kristal’s hurt shake | DELTARUNE’s hurt shake | Fixed hurt shake (this PR) |
|:---:|:---:|:---:|
| <img width="360" alt="Kristal hurt shake" src="https://github.com/user-attachments/assets/bdc787af-3be3-4b69-a42e-263bf5f713c4"> | <img width="360" alt="DELTARUNE hurt shake" src="https://github.com/user-attachments/assets/dc0cd49a-75f9-46c4-a54a-4685495248fe"> | <img width="360" alt="kristal fixed shake" src="https://github.com/user-attachments/assets/91c0bb1e-90f4-4d6a-8e9c-a1183c229e78" />

| Kristal’s defeatrun animation | DELTARUNE’s defeatrun animation | Fixed defeatrun animation (this PR) |
|:---:|:---:|:---:|
| <img width="360" alt="kristal defeatrun" src="https://github.com/user-attachments/assets/b6b3fc35-8125-4f88-a309-643b52f460d5" /> | <img width="360" alt="original defeatrun" src="https://github.com/user-attachments/assets/9c508070-002f-4511-a049-df6f659318b2" /> | <img width="360" alt="kristal fixed defeatrun" src="https://github.com/user-attachments/assets/65bc782b-177b-41c5-88b0-41f0772df115" />
