### PR TITLE
Makes it impossible to give a "nan" amount of money in the debug options

### DIFF
--- a/src/engine/game/debugsystem.lua
+++ b/src/engine/game/debugsystem.lua
@@ -1229,7 +1229,7 @@ function DebugSystem:registerDefaults()
                 function(text)
                     local money = tonumber(text)
                     if money then
-                        if not MathUtils.isNaN(money) and not money == math.huge then
+                        if not MathUtils.isNaN(money) and not (money == math.huge) then
                             if Game:isLight() then
                                 Game.lw_money = Game.lw_money + money
                             else

--- a/src/engine/game/debugsystem.lua
+++ b/src/engine/game/debugsystem.lua
@@ -1229,12 +1229,14 @@ function DebugSystem:registerDefaults()
                 function(text)
                     local money = tonumber(text)
                     if money then
-                        if Game:isLight() then
-                            Game.lw_money = Game.lw_money + money
-                        else
-                            Game.money = Game.money + money
+                        if not MathUtils.isNaN(money) and not money == math.huge then
+                            if Game:isLight() then
+                                Game.lw_money = Game.lw_money + money
+                            else
+                                Game.money = Game.money + money
+                            end
+                            Assets.stopAndPlaySound("bell_bounce_short")
                         end
-                        Assets.stopAndPlaySound("bell_bounce_short")
                     end
                 end
             )

--- a/src/engine/menu/mainmenucredits.lua
+++ b/src/engine/menu/mainmenucredits.lua
@@ -81,13 +81,14 @@ function MainMenuCredits:init(menu)
                 "Nextop",
                 "nightpool",
                 "prokube",
+                "raisinbrainguy",
                 "rfrx",
                 "Simbel",
-                "sjl057",
-                "skarph"
+                "sjl057"
             },
             {
                 { "GitHub Contributors", COLORS.silver },
+                "skarph",
                 "SuperOfSrb2",
                 "SweetSylveon",
                 "TFLTV",


### PR DESCRIPTION
Giving a nan amount of money can cause a lot of issues especially since we're adding and subtracting from it in shops _(I think one time it crashed)_ so hopefully this makes it impossible for that to happen!

I don't really mind if you decline this one because 0.1% of the Kristalites will ever do this, I **promise** I'll make actually good pull requests later :P

This is like those insane Instagram conspiracy reels if they were a commit