### PR TITLE
Fixed. Saving in the Light World woudn't save the spawn marker.

### DIFF
--- a/src/engine/game/world/events/savepoint.lua
+++ b/src/engine/game/world/events/savepoint.lua
@@ -71,7 +71,7 @@ function Savepoint:onTextEnd()
     end
 
     if Game:isLight() then
-        self.world:openMenu(LightSaveMenu(Game.save_id, self.marker))
+        self.world:openMenu(LightSaveMenu(self.marker))
     elseif self.simple_menu or (self.simple_menu == nil and Game:getConfig("smallSaveMenu")) then
         self.world:openMenu(SimpleSaveMenu(Game.save_id, self.marker))
     else


### PR DESCRIPTION
While working on a new project, I noticed that saving the game in the light word wouldn't reload the player at the marker set by the savepoint. After some more digging, I noticed that, when the savepoint creates the LightSaveMenu it does so by using:
```lua
self.world:openMenu(LightSaveMenu(Game.save_id, self.marker))
```
But LightSaveMenu only takes the marker as an init parameter:
```lua
function LightSaveMenu:init(marker)
```
This causes self.marker to be set to the selected save slot instead of the market, so the marker doesn't get written to the save file and the player spawns in the spawn marker upon respawning.
Deleting Game.save_id upon creating LightSaveMenu fixes this.