### PR TITLE
Fix the party's default equipment

### DIFF
--- a/data/party/kris.lua
+++ b/data/party/kris.lua
@@ -134,7 +134,7 @@ function character:init()
         self:setWeapon("mechasaber")
         self:setArmor(1, "amber_card")
         self:setArmor(2, "glowwrist")
-    elseif Game.chapter >= 4 then
+    elseif Game.chapter == 4 then
         self:setWeapon("saber10")
         self:setArmor(1, "gingerguard")
         self:setArmor(2, "glowwrist")

--- a/data/party/susie.lua
+++ b/data/party/susie.lua
@@ -147,10 +147,14 @@ function character:init()
         self:setWeapon("autoaxe")
         self:setArmor(1, "amber_card")
         self:setArmor(2, "glowwrist")
-    elseif Game.chapter >= 4 then
+    elseif Game.chapter == 4 then
         self:setWeapon("toxicaxe")
         self:setArmor(1, "gingerguard")
         self:setArmor(2, "glowwrist")
+    elseif Game.chapter >= 5 then
+        self:setWeapon("toxicaxe")
+        self:setArmor(1, "gingerguard")
+        self:setArmor(2, "gingerguard")
     end
 
     -- Default light world equipment item IDs (saves current equipment)


### PR DESCRIPTION
When starting from Chapter 5, Kris would still have their Chapter 4 default equipment by mistake. Also, added Susie's Chapter 5 default equipment, that wasn't there at all previously.